### PR TITLE
fix: prevent ItemSelector panel from shrinking when searching items

### DIFF
--- a/pospire/public/js/posapp/components/pos/ItemsSelector.vue
+++ b/pospire/public/js/posapp/components/pos/ItemsSelector.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="enhanced-items-container pos-panel-container">
-		<v-card class="selection mx-auto pos-scrollable-content" elevation="2" rounded="lg">
+		<v-card class="selection pos-scrollable-content" elevation="2" rounded="lg">
 			<v-progress-linear
 				:active="loading"
 				:indeterminate="loading"
@@ -938,6 +938,7 @@ export default {
 /* Main content card - takes remaining space above controls */
 .selection {
 	flex: 1;
+	width: 100%;
 	min-height: 0;
 	overflow: hidden;
 }


### PR DESCRIPTION
- The mx-auto class on the selection v-card caused margin-left/right: auto, which overrides flex align-self: stretch in the column layout.
-  When search results narrowed to few items, the card collapsed to content width instead of maintaining full panel width. Removed mx-auto and added explicit width: 100% to ensure consistent layout.