### PR TITLE
chore: add frappe-dependencies to pyproject.toml for Marketplace compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
 requires = ["flit_core >=3.4,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.bench.frappe-dependencies]
+frappe = ">=15.0.0,<16.0.0"
+
 # These dependencies are only installed when developer mode is enabled
 [tool.bench.dev-dependencies]
 # package_name = "~=1.1.0"


### PR DESCRIPTION
## Summary
- Added `[tool.bench.frappe-dependencies]` section to `pyproject.toml` with `frappe = ">=15.0.0,<16.0.0"`
- Resolves Frappe Cloud Marketplace error: "Could not find compatible Frappe version in pyproject.toml file"

## Test plan
- [ ] Verify Marketplace "Add App" no longer shows the compatibility error
