### PR TITLE
fix(install): drop manual frappe.db.commit() in after_install

### DIFF
--- a/pospire/install.py
+++ b/pospire/install.py
@@ -60,5 +60,3 @@ def seed_default_denomination_data():
 						}
 					)
 					doc.insert(ignore_permissions=True)
-
-	frappe.db.commit()


### PR DESCRIPTION
## Summary
- Removes the manual `frappe.db.commit()` at the end of `seed_default_denomination_data()` in `pospire/install.py`. Frappe commits the install transaction itself once `after_install` returns, so this call was redundant.
- Resolves the **Semgrep `frappe-manual-commit`** finding on `pospire/install.py:64` raised by the Frappe Marketplace audit (Correctness · Minor).

## Why
Manual commits inside framework-managed transactions break partial-rollback semantics and test isolation. The seed routine only calls `doc.insert(...)`, which already participates in the install transaction Frappe wraps around `after_install`. No explicit commit is needed.

## Test plan
- [ ] Fresh install of the app on a new site (`bench --site <s> install-app pospire`) seeds the default `POS Denomination` records exactly as before.
- [ ] Re-running install (idempotent path) does not produce duplicates — guarded by `frappe.db.exists(...)`.
- [ ] `pre-commit run --files pospire/install.py` passes (ruff + ruff-format).
- [ ] Semgrep no longer reports `frappe-manual-commit` in `pospire/install.py`.