### PR TITLE
fix(audit): backfill nosemgrep comment format into version_16_dev

### DIFF
--- a/pospire/pospire/utils/pos_server_cache.py
+++ b/pospire/pospire/utils/pos_server_cache.py
@@ -91,7 +91,7 @@ def invalidate_pos_server_cache_from_doc(doc, method=None) -> None:
 		# tracking of which users run POS sessions for which profiles.
 		# The frontend guards on `data.pos_profile === this.pos_profile.name`
 		# so only the matching session acts on the event.
-		frappe.publish_realtime(  # nosemgrep: frappe-semgrep-rules.rules.frappe-realtime-pick-room
+		frappe.publish_realtime(  # nosemgrep: frappe-realtime-pick-room
 			"pos_profile_updated",
 			{"pos_profile": doc.name},
 			after_commit=True,
@@ -111,7 +111,7 @@ def invalidate_pos_server_cache_from_doc(doc, method=None) -> None:
 		# affect every profile.  No user-scoping is possible without session
 		# tracking infrastructure; the frontend decides which catalogs to refresh
 		# based on the payload flags.
-		frappe.publish_realtime(  # nosemgrep: frappe-semgrep-rules.rules.frappe-realtime-pick-room
+		frappe.publish_realtime(  # nosemgrep: frappe-realtime-pick-room
 			"pos_master_data_invalidated",
 			{
 				"doctype": doc.doctype,


### PR DESCRIPTION
Cherry-pick of `aa772e5` from `version-16`.

Marketplace auditor requires the short rule ID form (`frappe-realtime-pick-room`). The two `frappe.publish_realtime` calls in `pos_server_cache.py` were using the fully-qualified form, causing Critical findings. Backfills the fix that cleared those findings on `version-16`.