### PR TITLE
fix(offline): faster offline detection and immediate banner recovery

### DIFF
--- a/frontend/src/offline/connectivity.ts
+++ b/frontend/src/offline/connectivity.ts
@@ -227,7 +227,9 @@ export function drainLog(): ConnectivityLogEntry[] {
  *   - On success: bypasses the THRESHOLD_ONLINE 3-success rule and transitions
  *     directly to ONLINE if currently OFFLINE/DEGRADED. Rationale — the user
  *     made an affirmative request; if a single ping succeeds we trust it,
- *     and auto-detection takes over from there.
+ *     and auto-detection takes over from there. Also bypasses the D-31
+ *     debounce so the banner clears immediately — the debounce guards against
+ *     automated polling flap; it should not delay explicit cashier recovery.
  *   - On failure: increments consecutiveFailures normally (no special
  *     treatment). May or may not push to OFFLINE depending on threshold.
  *
@@ -266,6 +268,11 @@ export async function forcePingNow(): Promise<boolean> {
 		state.consecutiveSuccesses = THRESHOLD_ONLINE;
 		if (!isStateOnline(state.status)) {
 			transition("online", "force_ping_success");
+			// Notify immediately — the D-31 debounce inside transition() guards
+			// against automated polling flap and must not delay an explicit
+			// cashier tap. The debounced setTimeout fires later but is a no-op
+			// (Vue ref equality prevents a re-render on unchanged state).
+			notify();
 		}
 		return true;
 	} catch {

--- a/frontend/src/offline/connectivity.ts
+++ b/frontend/src/offline/connectivity.ts
@@ -302,6 +302,12 @@ function nextCadence(): number {
 	const multiplier = hidden ? BACKGROUND_MULTIPLIER : 1;
 
 	if (isStateOnline(state.status)) {
+		// Pending-offline fast path: first failure recorded but threshold not
+		// yet reached. Use the offline start cadence (5s) so the confirmation
+		// ping arrives quickly instead of waiting the full 30s online interval.
+		if (state.consecutiveFailures > 0) {
+			return CADENCE_OFFLINE_START_MS * multiplier;
+		}
 		const elapsed = Date.now() - lastRealSuccessAt;
 		if (elapsed < RECENT_SUCCESS_SKIP_MS) {
 			return Math.max(CADENCE_ONLINE_MS - elapsed, 1000) * multiplier;


### PR DESCRIPTION
Two bug fixes in the connectivity detector (`frontend/src/offline/connectivity.ts`):

1. **Offline banner was slow to appear (~40s)** — after the first ping failure, the next ping was still scheduled on the 30s online interval. Now drops to 5s, so the banner shows in ~15s.

2. **"Try connection now" didn't clear the banner immediately** — tapping the button fired a ping and succeeded, but the banner still waited 10–30s to hide. Now clears instantly on success.