### PR TITLE
fix(offline): close-shift enrichment, idempotent close, and snapshot reload safety

### DIFF
--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -98,23 +98,6 @@ export default {
 
 	methods: {
 		async check_opening_entry() {
-			// B3 — stale-while-revalidate shift-open hydration.
-			//
-			// Strategy:
-			//   1. Synchronously read the cached snapshot. If fresh (<24h),
-			//      register it immediately so the cashier sees a populated UI
-			//      in milliseconds, even on a cold boot.
-			//   2. Fire the live `check_opening_shift` in the background. If
-			//      it returns a meaningfully different snapshot (different
-			//      shift name or pos_profile.modified), re-emit
-			//      register_pos_profile so downstream panels reload without a
-			//      manual refresh.
-			//   3. If the live call fails AND no fresh cache exists → fall
-			//      through to the opening dialog (cold start, no offline hint).
-			//
-			// The TTL is 24h: a stale-but-still-valid cache covers a typical
-			// overnight outage; older than that and we'd rather make the
-			// cashier reconnect than serve potentially-corrupt data.
 			const SNAPSHOT_KEY = "pospire.opening_shift_snapshot";
 			const SNAPSHOT_META_KEY = "pospire.opening_shift_snapshot.meta";
 			const SNAPSHOT_TTL_MS = 24 * 60 * 60 * 1000;
@@ -141,9 +124,6 @@ export default {
 					this.persistOpeningSnapshot(r, SNAPSHOT_KEY, SNAPSHOT_META_KEY);
 				}
 			} catch (err) {
-				// liveCallSucceeded stays false. If we already registered the
-				// cache, swallow — banner tells the cashier they're offline.
-				// If we haven't, we'll fall through to the opening dialog.
 				if (!registeredFromCache) {
 					console.warn(
 						"[Pos] check_opening_shift failed and no fresh snapshot cached",
@@ -153,39 +133,21 @@ export default {
 			}
 
 			if (r) {
-				// Compare-and-swap: only re-emit register_pos_profile when the
-				// fresh response disagrees with what we already showed. This
-				// avoids a re-render storm on every boot when nothing changed.
-				if (
-					!registeredFromCache ||
-					this.openingSnapshotDiffers(cachedSnapshot, r)
-				) {
+				if (!registeredFromCache || this.openingSnapshotDiffers(cachedSnapshot, r)) {
 					this.applyOpeningSnapshot(r);
 				} else {
-					// Still keep the in-memory pos_profile / pos_opening_shift
-					// pointing at the live response so any field the cache lost
-					// (e.g. the `modified` timestamp) is current.
 					this.pos_profile = r.pos_profile;
 					this.pos_opening_shift = r.pos_opening_shift;
 				}
 				console.info("LoadPosProfile");
-			} else if (liveCallSucceeded) {
-				// Server is reachable AND says there is no open shift. The
-				// cached snapshot (if any) is now stale — the shift was closed
-				// on another device, expired, or never existed. Invalidate
-				// the cache, clear the in-memory references, and route the
-				// cashier to the opening dialog so they don't keep selling
-				// against a phantom shift.
+			} else if (liveCallSucceeded && !cachedSnapshot?.pos_opening_shift?.pospire_pending_sync) {
 				this.invalidateOpeningSnapshot(SNAPSHOT_KEY, SNAPSHOT_META_KEY);
 				this.pos_profile = "";
 				this.pos_opening_shift = "";
 				this.create_opening_voucher();
 			} else if (!registeredFromCache) {
-				// Live call failed AND no cache → cold start, open dialog.
 				this.create_opening_voucher();
 			}
-			// (Live call failed AND we registered from cache → keep using
-			// the cache. The cashier is offline; the banner explains it.)
 		},
 
 		readCachedOpeningSnapshot(key, metaKey, ttlMs) {
@@ -196,8 +158,6 @@ export default {
 				if (!parsed || !parsed.pos_profile || !parsed.pos_opening_shift) {
 					return null;
 				}
-				// TTL gate. The meta key holds `cached_at` so the snapshot blob
-				// stays exactly the shape the live API returns.
 				const metaRaw = localStorage.getItem(metaKey);
 				if (!metaRaw) return null;
 				const meta = JSON.parse(metaRaw);
@@ -226,29 +186,20 @@ export default {
 			}
 		},
 
-		/**
-		 * Wipe the cached opening snapshot. Called when the server confirms
-		 * that no shift is open — the cache is now actively misleading and
-		 * has to be cleared before the cashier can be redirected to the
-		 * opening dialog.
-		 */
 		invalidateOpeningSnapshot(key, metaKey) {
 			try {
-				localStorage.removeItem(key);
 				localStorage.removeItem(metaKey);
+				const raw = localStorage.getItem(key);
+				if (raw) {
+					const parsed = JSON.parse(raw);
+					parsed.pos_opening_shift = null;
+					localStorage.setItem(key, JSON.stringify(parsed));
+				}
 			} catch {
 				/* private mode */
 			}
 		},
 
-		/**
-		 * Decide whether the live response is materially different from the
-		 * cached one. We compare:
-		 *   - Opening shift NAME — different shifts entirely.
-		 *   - POS Profile modified timestamp — config edited mid-shift.
-		 * Anything else (balance_details aging, taxes recomputed) is
-		 * downstream and not worth a re-emit.
-		 */
 		openingSnapshotDiffers(cached, live) {
 			if (!cached) return true;
 			if (
@@ -271,9 +222,6 @@ export default {
 			this.get_offers(this.pos_profile.name);
 			this.eventBus.emit("register_pos_profile", snapshot);
 			this.eventBus.emit("set_company", snapshot.company);
-			// H4: if this shift was locked because an offline closing was
-			// queued before reload, re-emit the lock event so Invoice.vue
-			// re-arms the add_item / show_payment refusals after hydrate.
 			if (snapshot.pos_opening_shift?.pospire_closing_pending) {
 				this.eventBus.emit("shift_closing_pending", {
 					shift_offline_id: snapshot.pos_opening_shift?.pos_offline_id,
@@ -281,9 +229,6 @@ export default {
 						snapshot.pos_opening_shift?.pospire_pending_closing_offline_id,
 				});
 			}
-			// B5 — feed the observability beacon with the active outlet/shift
-			// so dashboards can group device pings by store. Free-form outlet
-			// label falls back to the POS Profile name.
 			try {
 				setBeaconContext({
 					outlet:
@@ -296,13 +241,6 @@ export default {
 			} catch (err) {
 				console.warn("[Pos] setBeaconContext failed", err);
 			}
-			// Warm the customer-form-options read cache (Customer Group /
-			// Territory / Gender lists). This path fires on every boot —
-			// including reload-from-cache and new-tab — not only when the
-			// opening dialog runs. Without this, the cache was only warmed
-			// via register_pos_data (emitted by OpeningDialog.vue), so a
-			// cashier who reloaded with an existing shift would get empty
-			// dropdowns on the Create Customer dialog when offline.
 			this.warm_customer_form_options_cache();
 		},
 		create_opening_voucher() {
@@ -318,12 +256,6 @@ export default {
 					}
 				);
 			} catch (err) {
-				// Offline / transport failure — synthesise a minimal closing
-				// shape from the cached opening shift so the cashier can still
-				// enter their physical denominations. Aggregated expected
-				// amounts (sum of invoices for this shift) require server-side
-				// SQL across synced docs and aren't available offline; the
-				// reconciliation banner in the dialog tells the cashier why.
 				console.warn("[Pos] make_closing_shift offline fallback", err);
 				r = this.buildOfflineClosingStub();
 			}
@@ -331,12 +263,6 @@ export default {
 				this.eventBus.emit("open_ClosingDialog", r);
 			}
 		},
-		/**
-		 * Synthesise the data shape `open_ClosingDialog` expects when
-		 * `make_closing_shift_from_opening` is unreachable. Opening amounts
-		 * come from the cached opening shift; expected_amount is left equal
-		 * to opening (the cashier reconciles after sync).
-		 */
 		buildOfflineClosingStub() {
 			const opening = this.pos_opening_shift || {};
 			const balance = Array.isArray(opening.balance_details)
@@ -345,8 +271,6 @@ export default {
 			const payment_reconciliation = balance.map((row) => ({
 				mode_of_payment: row.mode_of_payment,
 				opening_amount: row.amount || 0,
-				// expected_amount stays equal to opening — invoices for this
-				// shift haven't aggregated server-side yet.
 				expected_amount: row.amount || 0,
 				closing_amount: 0,
 				difference: 0,
@@ -383,12 +307,6 @@ export default {
 				invoice_offline_ids: await this.collectShiftInvoiceOfflineIds(),
 			};
 
-			// Pre-flight: if the active shift already has a queued closing OR
-			// any unsynced invoice in the local outbox, sending this close via
-			// the live path would close the shift on the server before the
-			// queued writes drain — orphaning every queued invoice (validate_shift
-			// throws "POS Shift X is not open"). forceQueue routes through the
-			// offline endpoint so strict-closure waits for siblings to sync.
 			const closeRoute = await this.classifyCloseRoute();
 			if (closeRoute === "already-queued") {
 				toast.warning(
@@ -409,35 +327,21 @@ export default {
 			} catch (err) {
 				console.error("[Pos] submit_closing_shift failed", err);
 				toast.error(err && err.message ? err.message : __("Failed to close shift"));
+				this.check_opening_entry();
 				return;
 			}
-				// Offline ack — closing is queued. Server-side strict closure on
-				// each retry blocks until every invoice in the shift has synced;
-				// once they do, the closing fires automatically.
 				if (r && r.offline === true && r.status === "enqueued") {
 					this.pendingClosingOfflineId = r.offline_id;
 					toast.info(
 						__("Shift close queued. It will finalise once every invoice in this shift has synced."),
 						{ autoClose: 5000 },
 					);
-				// Freeze the local shift: any invoice rung up after this point
-				// would NOT be in the closing's parent_offline_ids (we
-				// captured the sibling list at queue time), so the server
-				// would either reject the closing as having orphan siblings
-				// or — worse — submit the closing AND then submit a stray
-				// invoice under the now-closed shift. Lock the shift locally
-				// and re-route to the opening dialog so the cashier opens a
-				// new shift if they need to keep selling. The lock releases
-				// when the closing's onSynced fires.
 				if (this.pos_opening_shift) {
 					this.pos_opening_shift = {
 						...this.pos_opening_shift,
 						pospire_closing_pending: true,
 						pospire_pending_closing_offline_id: r.offline_id,
 					};
-					// Mirror onto the localStorage snapshot so a hard reload
-					// preserves the lock. The snapshot is the authoritative
-					// boot-time state for the cashier.
 					try {
 						const raw = localStorage.getItem("pospire.opening_shift_snapshot");
 						if (raw) {
@@ -455,18 +359,10 @@ export default {
 						/* non-fatal */
 					}
 				}
-				// Notify the cart layer (Invoice.vue) so add_item /
-				// show_payment refuse new actions on the locked shift.
 				this.eventBus.emit("shift_closing_pending", {
 					shift_offline_id: this.pos_opening_shift?.pos_offline_id,
 					closing_offline_id: r.offline_id,
 				});
-				// Re-route to the opening dialog (completing the intent stated
-				// in the comment above). Strip pos_opening_shift from the
-				// snapshot so a hard reload also falls through to the dialog
-				// rather than re-arming the closing lock. pos_profile and
-				// company stay intact — OpeningDialog uses them offline via
-				// synthesizeDialogDataFromShiftSnapshot.
 				try {
 					const raw = localStorage.getItem("pospire.opening_shift_snapshot");
 					if (raw) {
@@ -489,49 +385,6 @@ export default {
 				this.check_opening_entry();
 			}
 		},
-		/**
-		 * Collect every invoice offline_id that belongs to the current shift,
-		 * regardless of current outbox status. The server's strict-closure
-		 * check in `_ensure_all_invoices_submitted` requires the COMPLETE
-		 * sibling list — including invoices that are temporarily in
-		 * `needs_review`. If a `needs_review` row gets fixed and resyncs
-		 * later, the closing's `parent_offline_ids` must include it so the
-		 * scheduler unblocks the closing on its sync (cascade-unblock fires
-		 * from `markSynced` regardless of category).
-		 *
-		 * Two collection paths:
-		 *   1. Offline-opened shift (pos_offline_id present) — fast: index
-		 *      scan via `shift_offline_id` set at enqueue time.
-		 *   2. Online-opened shift (no pos_offline_id) — needs the inner
-		 *      `posa_pos_opening_shift` field which lives inside the encrypted
-		 *      invoice payload. We decrypt and match. Cost is bounded by the
-		 *      invoice count for the current shift (typically <100).
-		 *
-		 * The previous version returned `[]` for online-opened shifts, so
-		 * the closing payload shipped without sibling ids and the server's
-		 * orphan check rejected the closing as siblings_not_ready. With no
-		 * parent_offline_ids on the closing's outbox row, scheduler
-		 * cascade-unblock had nothing to react to, leaving the manager to
-		 * void + retry by hand.
-		 */
-		/**
-		 * Decide how to route a Close Shift action based on the local outbox
-		 * state for the active shift:
-		 *
-		 *   "already-queued" → an unsynced closing_entry exists for this shift;
-		 *     refuse a second close so we don't enqueue a duplicate that the
-		 *     server would reject (and so we don't fire a redundant live close
-		 *     that closes the shift before sibling invoices drain).
-		 *   "force-queue"    → no queued closing yet, but unsynced invoices
-		 *     exist for this shift. The closing MUST go through the outbox so
-		 *     strict-closure (P-8) waits for every sibling. A live close here
-		 *     would orphan the queued invoices via validate_shift.
-		 *   "live"           → no queued activity for this shift; the live path
-		 *     is safe (call() will still enqueue if currently offline).
-		 *
-		 * Failure modes (Dexie unavailable, kill switch off, etc.) fall through
-		 * to "live" — better to let the cashier close than to wedge the UI.
-		 */
 		async classifyCloseRoute() {
 			const openingOfflineId = this.pos_opening_shift?.pos_offline_id;
 			const openingServerName = this.pos_opening_shift?.name;
@@ -581,6 +434,8 @@ export default {
 			const openingOfflineId = this.pos_opening_shift?.pos_offline_id;
 			const openingServerName = this.pos_opening_shift?.name;
 			if (!openingOfflineId && !openingServerName) return [];
+
+			const merged = new Set();
 			try {
 				const { listByStatus } = await import("@/offline/outbox");
 				const all = await Promise.all([
@@ -593,42 +448,47 @@ export default {
 				const flat = all.flat();
 				const invoiceRows = flat.filter((row) => row.type === "invoice");
 
-				// Fast path: index match on shift_offline_id.
 				if (openingOfflineId) {
-					return invoiceRows
+					invoiceRows
 						.filter((row) => row.shift_offline_id === openingOfflineId)
-						.map((row) => row.offline_id);
-				}
-
-				// Slow path (online-opened shift): inspect each invoice's
-				// inner doc to match by real shift name. The outbox repo
-				// returns rows with the payload field already decrypted.
-				const matches = [];
-				for (const row of invoiceRows) {
-					if (row.shift_offline_id) continue; // belongs to a different (offline) shift
-					const inner = this.unwrapInnerInvoicePayload(row.payload);
-					if (
-						inner &&
-						(inner.posa_pos_opening_shift === openingServerName ||
-							inner.pos_opening_shift === openingServerName)
-					) {
-						matches.push(row.offline_id);
+						.forEach((row) => merged.add(row.offline_id));
+				} else {
+					for (const row of invoiceRows) {
+						if (row.shift_offline_id) continue;
+						const inner = this.unwrapInnerInvoicePayload(row.payload);
+						if (
+							inner &&
+							(inner.posa_pos_opening_shift === openingServerName ||
+								inner.pos_opening_shift === openingServerName)
+						) {
+							merged.add(row.offline_id);
+						}
 					}
 				}
-				return matches;
 			} catch (err) {
-				console.warn("[Pos] collectShiftInvoiceOfflineIds failed", err);
-				return [];
+				console.warn("[Pos] collectShiftInvoiceOfflineIds local scan failed", err);
 			}
+
+			try {
+				const { call } = await import("@/utils/call");
+				const serverIds = await call({
+					method: "pospire.pospire.api.offline.get_shift_invoice_offline_ids",
+					args: {
+						opening_shift_name: openingServerName ?? null,
+						opening_shift_offline_id: openingOfflineId ?? null,
+					},
+					intent: "read",
+				});
+				if (Array.isArray(serverIds)) {
+					serverIds.forEach((id) => { if (id) merged.add(id); });
+				}
+			} catch (err) {
+				console.warn("[Pos] collectShiftInvoiceOfflineIds server fetch failed", err);
+			}
+
+			return [...merged];
 		},
 
-		/**
-		 * Outbox payloads for offline-capable writes follow the wrapper
-		 * shape `{ data: "<JSON-stringified inner doc>", offline_id, … }`.
-		 * Strip the wrapper so callers can read inner fields like
-		 * `posa_pos_opening_shift` without re-implementing the parse on
-		 * every site.
-		 */
 		unwrapInnerInvoicePayload(payload) {
 			if (!payload || typeof payload !== "object") return null;
 			if (typeof payload.data === "string") {
@@ -759,12 +619,13 @@ export default {
 				this.get_offers(this.pos_profile.name);
 				this.pos_opening_shift = data.pos_opening_shift;
 				this.eventBus.emit("register_pos_profile", data);
-				// Warm the offline read-cache for the Create / Update
-				// Customer dialog's dropdowns (Customer Group, Territory,
-				// Gender) while we're definitely online (shift just opened).
-				// Fire-and-forget: a failure here is non-fatal — the dialog
-				// will retry on its own first open and surface any error
-				// there if the cashier never had a successful warm fetch.
+				if (data.pos_profile && data.company) {
+					this.persistOpeningSnapshot(
+						data,
+						"pospire.opening_shift_snapshot",
+						"pospire.opening_shift_snapshot.meta",
+					);
+				}
 				this.warm_customer_form_options_cache();
 				console.info("LoadPosProfile");
 			});

--- a/frontend/src/offline/beacon.ts
+++ b/frontend/src/offline/beacon.ts
@@ -1,26 +1,9 @@
 /**
- * B5 — Multi-outlet observability beacon.
+ * Multi-outlet observability beacon.
  *
- * Every BEACON_INTERVAL_MS the device snapshots its offline-pipeline health
- * and POSTs to `pospire.pospire.api.offline.record_beacon`. The server
- * inserts a `POS Offline Beacon` row; B6's central dashboard queries those.
- *
- * Why a dedicated beacon (not piggy-backing on `log_batch`):
- *   - log_batch writes to Error Log — text-only, hard to aggregate.
- *   - The dashboard wants typed fields (queue_depth, online flag, outlet
- *     name) that an Error Log row can't expose to a Frappe Report Builder
- *     view. Cost is a tiny doctype.
- *
- * Behaviour rules:
- *   - We DON'T fire while offline — the call would just bounce off the
- *     connectivity gate. Instead, we capture the next online tick and fire
- *     a single immediate beacon so the server sees the "I just came back"
- *     signal without a 5-minute lag.
- *   - We send a beacon on visibility change (tab refocused) so dashboards
- *     don't have to wait the full interval to see a manager opening the
- *     POS after a coffee break.
- *   - We back off on persistent failures: 3 consecutive failures pauses
- *     beaconing for 30 minutes (still respecting connectivity changes).
+ * Every BEACON_INTERVAL_MS, snapshots offline-pipeline health and POSTs to
+ * `record_beacon`. Fires immediately on reconnect and on tab visibility change.
+ * Backs off 30 min after 3 consecutive failures.
  */
 
 import { call } from "@/utils/call";
@@ -121,11 +104,7 @@ export function startBeacon(hints: BeaconContextHints = {}): void {
 		document.addEventListener("visibilitychange", onVisibilityChange);
 	}
 
-	// Connectivity transition: when we come back online from a long-offline
-	// window, fire one beacon immediately so the dashboard's "last seen"
-	// timestamp catches up. The connectivity module's onChange fires on
-	// state transitions (online | offline | degraded), so we filter to
-	// online-arrivals only.
+	// Fire immediately on reconnect so "last seen" catches up without waiting the full interval.
 	state.connectivityUnsub = connectivity.onChange((cs) => {
 		if (cs && cs.status === "online") {
 			void fireBeacon();
@@ -231,27 +210,18 @@ async function assembleBeacon(): Promise<Record<string, unknown>> {
 		.where("status")
 		.equals("needs_review")
 		.count();
-	// Tombstone count — handed off to the server review queue, awaiting
-	// manager retry / void. Phase 1g — surfaces the size of the manager
-	// backlog per device on the observability dashboard.
+	// Count handed-off tombstones awaiting manager retry/void.
 	const handedOff = await db.outbox
 		.where("status")
 		.equals("handed_off")
 		.count();
 
-	// Oldest pending — actual MIN(enqueued_at) across rows in pending
-	// statuses. Note: Dexie's `.where(...).first()` returns the first
-	// match in primary-key (offline_id) order, NOT the smallest
-	// enqueued_at — that produced incorrect staleness numbers. Bounded
-	// scan + in-memory min mirrors the pattern in stores/outbox.ts.
+	// Actual MIN(enqueued_at) — Dexie .first() uses primary-key order, not time.
 	const oldest = await minEnqueuedAtForStatuses(["enqueued", "retry_pending"]);
 	const oldestMinutes =
 		oldest === null ? null : Math.max(0, Math.floor((Date.now() - oldest) / 60_000));
 
-	// Oldest handed-off tombstone (by enqueued_at — the original moment
-	// the cashier created the queued write). Captures the WORST-case
-	// staleness from the cashier's perspective: how long has my oldest
-	// stuck transaction been sitting? Operational SLA signal.
+	// Oldest stuck tombstone by original enqueue time — worst-case staleness signal.
 	const oldestHandedOff = await minEnqueuedAtForStatuses(["handed_off"]);
 	const oldestHandedOffMinutes =
 		oldestHandedOff === null
@@ -281,17 +251,7 @@ async function assembleBeacon(): Promise<Record<string, unknown>> {
 	};
 }
 
-/**
- * True MIN(enqueued_at) across rows in any of the given statuses, or
- * null if there are no matching rows. Bounded scan in JS rather than
- * relying on Dexie's `.first()`, which walks the index in primary-key
- * order (offline_id is a UUID — order is effectively random) instead
- * of by enqueued_at. With queue depths in the low thousands at most
- * the scan cost is negligible vs. the wrong-answer risk.
- *
- * Bounded at 5000 rows per status to defend against pathological depths.
- * In healthy operation queue depth stays well under that.
- */
+/** True MIN(enqueued_at) across rows in any given status. Bounded scan — Dexie .first() uses primary-key order, not time. */
 async function minEnqueuedAtForStatuses(
 	statuses: string[],
 	cap = 5000,

--- a/frontend/src/offline/connectivity.ts
+++ b/frontend/src/offline/connectivity.ts
@@ -1,22 +1,10 @@
 /**
- * Connectivity detector — single source of truth for "is the server
- * reachable right now." Feeds `@/utils/call`, the outbox sync scheduler, and
- * the UI banner (04-connectivity-detection.md).
+ * Connectivity detector — single source of truth for "is the server reachable."
+ * Feeds call(), the sync scheduler, and the UI banner.
  *
- * Design:
- *   - Three signals feed one state machine: `navigator.onLine`, heartbeat
- *     ping (pospire.pospire.api.offline.ping), observed fetch outcomes.
- *   - Asymmetric thresholds: 2 consecutive ping failures → OFFLINE;
- *     3 consecutive ping successes → ONLINE. Going online is riskier.
- *   - No recursive setTimeout that outlives the component; `stop()` is
- *     called on `Pos.vue` unmount.
- *   - DEGRADED is observable in the type union but is NOT currently emitted
- *     by `reportRequestOutcome` — Phase 1 ships binary online/offline only.
- *     Wiring DEGRADED is a Phase 2 task: introduce an RTT band (e.g. > 500ms
- *     for N consecutive pings → DEGRADED) and a corresponding transition.
- *     The OfflineBanner already has the amber DEGRADED state styled and
- *     copy-ready. See docs/offline/04-connectivity-detection.md §3 and the
- *     Phase 2 plan in docs/offline/16-phase-plan.md.
+ * Three signals drive one state machine: navigator.onLine, heartbeat ping, and
+ * observed fetch outcomes. Asymmetric thresholds: 2 failures → OFFLINE,
+ * 3 successes → ONLINE. stop() must be called on Pos.vue unmount.
  */
 
 import { frappeRequest } from "frappe-ui";
@@ -61,10 +49,10 @@ const CADENCE_OFFLINE_MAX_MS = 120_000;
 const BACKGROUND_MULTIPLIER = 2; // document.hidden → 2× cadence
 const RECENT_SUCCESS_SKIP_MS = 30_000; // skip ping if real call succeeded within
 
-const DEBOUNCE_DEFAULT_MS = 10_000; // D-31
-const DEBOUNCE_ESCALATED_MS = 30_000; // D-31
-const FLAP_WINDOW_MS = 5 * 60 * 1000; // D-31
-const FLAP_THRESHOLD_COUNT = 3; // D-31
+const DEBOUNCE_DEFAULT_MS = 10_000;
+const DEBOUNCE_ESCALATED_MS = 30_000;
+const FLAP_WINDOW_MS = 5 * 60 * 1000;
+const FLAP_THRESHOLD_COUNT = 3;
 
 const CONNECTIVITY_LOG_CAP = 500; // metadata.connectivity_log cap
 
@@ -113,7 +101,7 @@ export function getState(): ConnectivityState {
 	return { ...state };
 }
 
-/** Alias matching the spec (04-connectivity-detection.md §8). */
+/** Alias for getState(). */
 export function snapshot(): ConnectivityState {
 	return getState();
 }
@@ -135,11 +123,7 @@ export function onChange(fn: ConnectivityListener): () => void {
 	return () => listeners.delete(fn);
 }
 
-/**
- * Report the outcome of a real request issued by `@/utils/call`. This is
- * how real traffic drives transitions faster than pings alone
- * (04-connectivity-detection.md §6).
- */
+/** Report outcome of a real request; drives transitions faster than pings alone. */
 export function reportRequestOutcome(outcome: RequestOutcome): void {
 	switch (outcome) {
 		case "success":
@@ -174,11 +158,7 @@ export function clearManualOverride(): void {
 	notify();
 }
 
-/**
- * Start the detector. Idempotent. Should be called from `Pos.vue`'s
- * `onMounted` (or equivalent) so the lifecycle is owned by a single
- * component (P-6).
- */
+/** Start the detector. Idempotent. Called from Pos.vue onMounted. */
 export function start(): void {
 	if (started) return;
 	started = true;
@@ -219,22 +199,9 @@ export function drainLog(): ConnectivityLogEntry[] {
 }
 
 /**
- * User-initiated immediate ping. Bypasses the polling cadence so a cashier
- * who knows the network is back can recover faster than waiting for the next
- * scheduled ping.
- *
- * Semantics differ from auto-detection:
- *   - On success: bypasses the THRESHOLD_ONLINE 3-success rule and transitions
- *     directly to ONLINE if currently OFFLINE/DEGRADED. Rationale — the user
- *     made an affirmative request; if a single ping succeeds we trust it,
- *     and auto-detection takes over from there. Also bypasses the D-31
- *     debounce so the banner clears immediately — the debounce guards against
- *     automated polling flap; it should not delay explicit cashier recovery.
- *   - On failure: increments consecutiveFailures normally (no special
- *     treatment). May or may not push to OFFLINE depending on threshold.
- *
- * Returns whether the ping itself succeeded (not whether the state changed).
- * The banner uses this to drive a "still offline" toast on failure.
+ * User-initiated ping. Bypasses the 3-success threshold and debounce on success
+ * so the banner clears immediately. On failure, increments consecutiveFailures normally.
+ * Returns whether the ping succeeded (not whether state changed).
  */
 export async function forcePingNow(): Promise<boolean> {
 	const startedAt = Date.now();
@@ -263,15 +230,11 @@ export async function forcePingNow(): Promise<boolean> {
 			lastKnownServerVersion = res.server_version;
 		}
 
-		// User-initiated success: jump the threshold so a single tap recovers.
 		state.consecutiveFailures = 0;
 		state.consecutiveSuccesses = THRESHOLD_ONLINE;
 		if (!isStateOnline(state.status)) {
 			transition("online", "force_ping_success");
-			// Notify immediately — the D-31 debounce inside transition() guards
-			// against automated polling flap and must not delay an explicit
-			// cashier tap. The debounced setTimeout fires later but is a no-op
-			// (Vue ref equality prevents a re-render on unchanged state).
+			// Bypass the debounce — explicit cashier tap should clear the banner immediately.
 			notify();
 		}
 		return true;
@@ -466,7 +429,7 @@ function logConnectivity(
 }
 
 // ---------------------------------------------------------------------------
-// Spec-matching named export (04-connectivity-detection.md §8)
+// Named export
 // ---------------------------------------------------------------------------
 
 export const connectivity = {

--- a/frontend/src/offline/kill-switch.ts
+++ b/frontend/src/offline/kill-switch.ts
@@ -1,21 +1,9 @@
 /**
- * Global offline kill switch (D-29).
+ * Global offline kill switch.
  *
- * A system-wide single-value setting (`POSpire Offline Settings.enabled`,
- * default `true`) gates the entire offline code path. When the setting is
- * `false`:
- *
- *   - `outbox.enqueue` throws `OfflineDisabledError` so `call()` surfaces the
- *     banner-catchable error to the UI.
- *   - `SyncScheduler` pauses its drain loop; existing queued entries remain
- *     untouched until the switch flips back.
- *
- * Lookup strategy: cached with a short TTL so every enqueue doesn't round-trip.
- * Value is re-read via `call({ method: 'frappe.client.get_single_value', ...,
- * intent: 'read', cacheKey: 'offline.kill_switch', cacheTTLMs: 60_000 })` once
- * the setting doctype exists. Until Agent 6 ships the doctype, we use a
- * client-side default of `true` (offline enabled) so Phase 1 pilots are not
- * broken by a missing lookup.
+ * `POSpire Offline Settings.enabled` (default `true`) gates the entire offline code path.
+ * When false: enqueue throws `OfflineDisabledError`; the scheduler pauses.
+ * Lookup is cached with a short TTL to avoid a round-trip on every enqueue.
  */
 
 import type { OutboxType } from "./types";
@@ -30,25 +18,13 @@ export const KILL_SWITCH_CACHE_KEY = "offline.kill_switch";
 const KILL_SWITCH_FIELD = "enabled";
 /** TTL for the cached value. 60s keeps ops toggles snappy without spamming. */
 export const KILL_SWITCH_CACHE_TTL_MS = 60_000;
-/**
- * Client-side default until `POSpire Offline Settings` ships (Agent 6).
- * `true` = offline enabled.
- *
- * TODO(agent-6): replace the default-true branch below with a real
- * `call({ method: 'frappe.client.get_single_value', ... })` lookup once the
- * single-doctype exists. Keep the cache key + TTL in sync with this module.
- */
 const DEFAULT_ENABLED = true;
 
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
 
-/**
- * Thrown by `outbox.enqueue` when the kill switch is off. The banner / UI
- * catches this by `name === 'OfflineDisabledError'` and surfaces the
- * operator-friendly copy from 11-ui-ux.md §7.
- */
+/** Thrown by outbox.enqueue when the kill switch is off. Caught by name in the banner/UI. */
 export class OfflineDisabledError extends Error {
 	readonly outboxType: OutboxType | null;
 	constructor(outboxType: OutboxType | null = null) {
@@ -167,38 +143,14 @@ export function invalidateKillSwitchCache(): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetches the kill-switch value via a dedicated whitelisted endpoint.
- *
- * Why not `frappe.client.get_single_value` directly?
- *   The `POSpire Offline Settings` Single restricts read+write to System
- *   Manager (intentional — cashiers must not be able to mutate it). The
- *   generic client lookup permission-checks the doctype, so cashier
- *   sessions hit a 403 and the catch below would silently fall back to
- *   "enabled". That defeats the kill switch for the users it's supposed
- *   to gate.
- *
- *   `pospire.pospire.api.offline.is_offline_enabled` reads the bit through
- *   the DB layer (bypassing doctype permissions) and exposes ONLY the
- *   boolean. Any authenticated user can call it; only System Managers can
- *   change the underlying value through the Desk form.
- *
- * Cache key + TTL are honoured by call() so a poll every 60s costs at most
- * one round-trip per device per minute.
- *
- * Failure semantics: a transient lookup error (network blip, server
- * restart) must NOT flip the switch to disabled. Preserve the last-known
- * value (or the default) on error.
+ * Fetch via a dedicated endpoint rather than frappe.client.get_single_value —
+ * the doctype is System Manager–only, so cashier sessions would 403 the generic
+ * lookup and silently fall back to "enabled", defeating the switch.
+ * Errors preserve the last-known value; never treat failure as "disabled".
  */
 async function fetchKillSwitch(): Promise<boolean> {
-	// Short-circuit when the device is offline. There is no point firing a
-	// fetch against a known-down link — but more importantly, an offline
-	// fetch can resolve in surprising ways (an SW-served fallback envelope,
-	// a captive-portal HTML page, a 200 with an empty body) that
-	// `parseEnabled` may interpret as `false` and block legitimate offline
-	// enqueues. The kill switch is a runtime *online* signal; while offline
-	// we trust the last good reading (or the default = enabled) and let the
-	// scheduler re-check the real value the moment we reconnect, before any
-	// drain.
+	// Skip fetch while offline — SW fallbacks or captive portals can return
+	// a malformed 200 that parseEnabled reads as `false`, blocking enqueues.
 	try {
 		const { default: connectivity } = await import("./connectivity");
 		if (

--- a/frontend/src/offline/outbox.ts
+++ b/frontend/src/offline/outbox.ts
@@ -1,24 +1,12 @@
 /**
- * Outbox state machine (Agent 3).
+ * Outbox state machine.
  *
- * Sits on top of `repos/outbox.ts` (which owns Dexie CRUD) and implements the
- * write-ahead log's semantics: enqueue, ready-pickup, retry/backoff, error
- * classification, dependency resolution, void. The sync scheduler
- * (`sync.ts`) consumes this module; no component talks to it directly.
+ * Implements the write-ahead log semantics on top of `repos/outbox.ts`: enqueue,
+ * ready-pickup, retry/backoff, error classification, dependency resolution, void.
+ * Consumed by sync.ts; no component talks to it directly.
  *
- * Principles honoured (see 01-architecture-principles.md):
- *   P-5:  every queued write carries an immutable `offline_id`.
- *   P-7:  dependency order is mandatory — parents must be `synced` before a
- *         child ships.
- *   P-8:  strict closure — `closing_entry` waits for every invoice in its
- *         shift.
- *   P-11: `posting_date` and `owner_user` are snapshotted at enqueue time.
- *   P-14: persistence failures propagate; we never swallow.
- *
- * The enqueue path is atomic — a single Dexie transaction that writes the
- * outbox row and, for `closing_entry`, updates the owning `shifts` row. If
- * the transaction fails, the caller gets an error and surfaces it to the UI;
- * we do NOT retry the write silently (P-14).
+ * Enqueue is atomic — a single Dexie transaction. Persistence failures propagate;
+ * never swallowed silently.
  */
 
 import {
@@ -70,13 +58,7 @@ const VALID_TYPES = new Set<OutboxType>([
 	"closing_entry",
 ]);
 
-/**
- * Terminal error categories — the scheduler may call `markNeedsReview` with
- * any of these. `network_error` / `server_5xx` / `timeout` /
- * `idempotent_duplicate` are transient and must not land here. NOTE:
- * `integrity_mismatch` is a `blocked_reason`, not a `last_error_category`
- * (see `markIntegrityMismatch`).
- */
+/** Terminal error categories. Transient ones (network_error, server_5xx, timeout) must not land here. */
 const NEEDS_REVIEW_CATEGORIES = new Set<NonNullable<LastErrorCategory>>([
 	"validation_error",
 	"permission_error",
@@ -137,16 +119,7 @@ export interface SyncEvent {
 type SyncListener = (event: SyncEvent) => void;
 const syncListeners = new Set<SyncListener>();
 
-/**
- * Subscribe to sync notifications. Returns an unsubscribe.
- *
- * The primary consumer is the Vue layer: when a customer that was created
- * offline finally syncs, the cart's in-memory `customer` may still hold the
- * provisional `OFFLINE-CUST-...` name. Subscribers receive
- * `{ offline_id, server_doc_name, provisional_name }` and rename the
- * reference. The fan-in is small (Customer.vue + Invoice.vue), so a simple
- * Set is enough — no need for a typed event bus.
- */
+/** Subscribe to sync notifications. Returns an unsubscribe. */
 export function onSynced(fn: SyncListener): () => void {
 	syncListeners.add(fn);
 	return () => syncListeners.delete(fn);
@@ -502,32 +475,10 @@ export async function markNeedsReview(
 }
 
 /**
- * Vacuum transition: the server-side `POSpire Offline Sync Review` row
- * for this tombstone has reached a terminal state (Resolved or Voided)
- * and we can upgrade the local row accordingly. The tombstone has done
- * its job — children that referenced this offline_id can now resolve
- * their dependency check (Resolved → server doc exists, name returned;
- * Voided → blocked forever, but at least no longer ambiguous).
- *
- * Cascade behaviour:
- *   Resolved → cascade-unblock dependents (mirrors `markSynced`'s
- *     behavior for the natural-success path). Without this, children
- *     blocked on this parent stay `blocked_reason: waiting_for_parent`
- *     forever, because `evaluateParents` only runs from `nextReady` and
- *     `listReady` excludes blocked rows. Cascading clears the block
- *     flag so the next drain cycle picks them up; if other parents
- *     are still pending, evaluateParents re-blocks the child then.
- *     Also fires `notifySynced` (mirrors `markSynced`) so the cart
- *     swaps a provisional customer name for the real server name when
- *     the manager resolves the customer via the recovery UI.
- *   Voided → do NOT cascade. The parent never produced a server doc,
- *     so the child's offline_id reference is unresolvable. Per the
- *     runbook (§2.3), managers void descendants explicitly. Cascading
- *     here would just thrash: clear → re-evaluate → re-block as
- *     `waiting_for_parent` → noisy audit + wasted cycles.
- *
- * Idempotent. Calling twice with the same target is a no-op the second
- * time because the source state will no longer be `handed_off`.
+ * Upgrade a `handed_off` tombstone after the server-side review row reaches a terminal state.
+ * Resolved → synced (cascade-unblocks dependents + fires notifySynced).
+ * Voided → voided (no cascade — descendants must be voided explicitly).
+ * Idempotent.
  */
 export async function markVacuumed(
 	offlineId: string,
@@ -570,21 +521,8 @@ export async function markVacuumed(
 }
 
 /**
- * Tombstone transition: the row was successfully handed off to the
- * server-side `POSpire Offline Sync Review` queue. The local row stays
- * in IndexedDB so dependent rows (children referencing this offline_id
- * via `parent_offline_ids`, the shift's strict-closure check) can still
- * see it — but `listReady` excludes it, so the scheduler never picks it
- * up again. The `recovery_entry_name` field links to the server row so
- * the local vacuum pass can poll for resolution and eventually flip
- * this tombstone to `synced` (when the manager retries successfully) or
- * `voided` (when the manager voids).
- *
- * Idempotent: callers may invoke this multiple times with the same
- * recovery_entry_name (network retry on the handoff response). The CAS
- * pattern is unnecessary here because handoff itself is idempotent
- * server-side; if the scheduler hands off twice, both calls return the
- * same recovery row name and this transition writes the same value.
+ * Transition to `handed_off` tombstone. Row stays in IndexedDB for dependency resolution
+ * but is excluded from the drain queue. Idempotent — safe to call multiple times.
  */
 export async function markHandedOff(
 	offlineId: string,
@@ -721,17 +659,7 @@ export async function clearBlocked(offlineId: string): Promise<void> {
 	});
 }
 
-/**
- * Find all outbox rows that list `parentOfflineId` in their
- * `parent_offline_ids`, and clear their `blocked_reason` so they re-enter
- * the drain queue. Called from `markSynced` and `resetForRetry` to cascade-
- * unblock dependents when their parent transitions to a syncable state.
- *
- * `evaluateParents` re-runs at drain time, so if OTHER parents are still
- * in needs_review the row will be re-blocked then. Optimistic clearing
- * keeps the state machine moving without coupling the dependency graph
- * traversal into this helper.
- */
+/** Clear blocked_reason on rows that listed parentOfflineId as a parent. Optimistically unblocks; evaluateParents re-gates at drain time. */
 export async function clearDependentsBlockedOn(
 	parentOfflineId: string,
 ): Promise<void> {
@@ -783,12 +711,7 @@ export async function evaluateParents(
 		if (
 			parent.status === "needs_review" ||
 			parent.status === "voided" ||
-			// Tombstone for a row handed off to the server-side review queue.
-			// The work isn't done on the server yet (recovery row is Pending
-			// Review / Retrying), so this child cannot ship — its references
-			// to parent_offline_id won't resolve. The local vacuum pass
-			// flips the tombstone to `synced` once the server-side recovery
-			// row reaches Resolved, at which point the child unblocks.
+			// handed_off means the server-side recovery row is still pending; child must wait.
 			parent.status === "handed_off"
 		) {
 			blockedByParent = true;
@@ -801,24 +724,9 @@ export async function evaluateParents(
 }
 
 /**
- * Strict closure (P-8): a `closing_entry` may only ship once every invoice
- * belonging to the same shift has `status=synced`. Returns the same tri-state
- * as `evaluateParents`.
- *
- * Two scan modes:
- *   - Offline-opened shift: index seek on `shift_offline_id` (fast, uses
- *     the existing Dexie index).
- *   - Online-opened shift: `entry.shift_offline_id` is null, so the index
- *     seek would miss every sibling. Fall back to decrypting the closing's
- *     inner doc to learn the real shift name, then scan invoice rows by
- *     inner `posa_pos_opening_shift`. Cost is O(N invoice rows) with one
- *     JSON.parse per row — bounded by outbox depth, runs only when an
- *     online-opened shift's closing is in flight.
- *
- * Without the second branch a closing for an online-opened shift would
- * always report "ready" here, the scheduler would fire it immediately,
- * and the server's strict-closure orphan check would reject it as
- * siblings_not_ready. Manager would then have to void+retry manually.
+ * Gate a `closing_entry` until every invoice in the same shift is synced.
+ * Uses `shift_offline_id` index for offline-opened shifts; falls back to
+ * scanning invoice inner docs when the shift was opened online (shift_offline_id is null).
  */
 export async function evaluateClosingReadiness(
 	entry: OutboxEntry<unknown>,
@@ -903,39 +811,10 @@ function readInnerShiftName(payload: unknown): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Defensively pass payload through unchanged for the wrapper-shaped writes
- * the offline pipeline produces today.
- *
- * **Why this used to rewrite, and why it can't.**
- * The original intent was: if a parent has synced and we know its real
- * server doc name, replace the parent's offline UUID with that name in the
- * payload before sending. That sounds fine until you remember the wrapper
- * shape every offline-capable adapter produces:
- *
- *   { data: "<JSON inner doc>",            // string (NOT walked)
- *     offline_id: "<this row's UUID>",
- *     device_id: "<UUID>",
- *     opening_entry_offline_id: "<UUID>",  // PROTOCOL field — server
- *     material_receipt_offline_ids: [...]  //   resolves these to names
- *   }
- *
- * The wrapper's `opening_entry_offline_id` and `material_receipt_offline_ids`
- * elements ARE the parent UUIDs. A string-match deep-rewrite would replace
- * them with server doc names, after which the server's `_validate_uuid` /
- * `_resolve_opening_shift` / `_resolve_material_receipts` reject the
- * payload as "Invalid uuid". The server is already the authoritative
- * resolver — front-end pre-resolution is a no-op at best (inner doc lives
- * inside a JSON STRING the walker doesn't recurse into) and an active
- * sabotage at worst (wrapper protocol fields get rewritten).
- *
- * The function is kept as an explicit pass-through (not deleted) because
- * `sync.ts` calls it on every send. If a future non-wrapper outbox shape
- * needs front-end resolution, restore a *scoped* rewrite — never one that
- * walks protocol fields.
- *
- * P-7's gating still happens via `evaluateParents` + `evaluateClosingReadiness`
- * (we don't ship until parents are synced/voided). Server-side
- * `_resolve_*` then maps UUIDs to real doc names at submit time.
+ * Pass payload through unchanged. The server is the authoritative resolver of
+ * offline UUIDs to real doc names — front-end pre-resolution would corrupt
+ * wrapper protocol fields (`opening_entry_offline_id` etc.) that the server
+ * expects as UUIDs.
  */
 export async function resolvePayload<T>(
 	entry: OutboxEntry<T>,
@@ -1031,24 +910,8 @@ export async function countPending(): Promise<number> {
 }
 
 /**
- * F7 — Edit & Retry. Mutates the queued payload, re-encrypts, and re-queues
- * for the scheduler.
- *
- * Used by the per-category fix flows in the reconciliation workspace
- * (date-retry, serial-swap, detach-parent, detach-sibling). The caller
- * decrypts via `getEntry`, computes the desired payload, and hands the
- * mutated value back here. We:
- *   1. Re-encrypt under the same AAD (offline_id) so the audit hash chain
- *      stays bound to the original row identity.
- *   2. Recompute `payload_integrity_hash` so `verifyIntegrity` agrees.
- *   3. Update the indexed sibling columns `posting_date` / `parent_offline_ids`
- *      when the caller patches them (otherwise the scheduler's parent
- *      evaluator and the accounting-period check still see the old values).
- *   4. Reset status to `enqueued`, clear error fields, attempt_count=0.
- *   5. Notify enqueue listeners so the scheduler wakes immediately.
- *
- * Refuses on `voided` or `synced` rows — those are terminal. A synced row
- * already has a real server doc; the right tool is a reversal, not an edit.
+ * Edit & Retry: mutate the queued payload, re-encrypt, recompute integrity hash,
+ * reset status to enqueued, and wake the scheduler. Refuses on voided/synced rows.
  */
 export async function patchPayloadAndReset(
 	offlineId: string,
@@ -1117,11 +980,7 @@ export async function resetForRetry(offlineId: string): Promise<void> {
 	if (!stored) throw new Error(`outbox ${offlineId} not found`);
 	if (stored.status === "voided") return; // terminal — refuse to revive
 
-	// Build the post-update on-disk row, then persist it. Notify listeners
-	// with the SAME post-update shape (decrypted) — the prior version
-	// notified with the pre-update row, so subscribers (Pinia store, sync
-	// scheduler, telemetry) saw stale `status` / `last_error_category` /
-	// `attempt_count` immediately after a Retry click.
+	// Notify with post-update shape so subscribers see current status immediately.
 	const updatedStored = {
 		...stored,
 		status: "enqueued" as const,
@@ -1155,12 +1014,6 @@ function readDeviceId(): string {
 	}
 	return "unknown-device";
 }
-
-// `currentCashier` is sourced from the shared module at @/offline/cashier
-// so call-registry.ts adapters and outbox.ts agree on one implementation
-// (and one fallback ladder). The earlier two-copy state silently bypassed
-// the cookie fallback whenever an adapter pre-stamped owner_user via
-// `options.ownerUser`, since adapters used a less-safe local helper.
 
 function todayIsoDate(): string {
 	const d = new Date();

--- a/frontend/src/offline/sync.ts
+++ b/frontend/src/offline/sync.ts
@@ -1,26 +1,13 @@
 /**
- * Sync scheduler (Agent 3).
+ * Sync scheduler.
  *
  * Owns the drain loop that empties the outbox into the server, one entry at
  * a time, in dependency order. Leader-gated across tabs via the Web Locks
- * API (D-26) with a Dexie-lease fallback for older browsers. Pauses on
- * connectivity transitions, resumes on reconnect, and stops cleanly when
- * `Pos.vue` unmounts.
+ * API with a Dexie-lease fallback for older browsers. Pauses on connectivity
+ * transitions, resumes on reconnect, and stops cleanly when `Pos.vue` unmounts.
  *
- * Principles (see 01-architecture-principles.md):
- *   P-6:  one scheduler per device at a time. The exported singleton is
- *         intended to be `.start()`-ed from `Pos.vue` onMounted; until
- *         Phase 2 adds the component, we start at module import and never
- *         stop. Documented as a deviation below.
- *   P-7:  dependency ordered — `evaluateParents` + `evaluateClosingReadiness`
- *         gate every send.
- *   P-14: failures propagate. The scheduler classifies error categories and
- *         commits the outcome to Dexie before moving on.
- *
- * Observability: per-cycle summary appended to `metadata.sync_log`, capped
- * at 1,000 entries (05-outbox-and-sync.md §8). Uploaded to the server via
- * `pospire.pospire.api.offline.log_batch` on reconnect (wired from the
- * connectivity module's log flush; here we just append).
+ * Per-cycle summaries are appended to `metadata.sync_log` (capped at 1,000)
+ * and uploaded via `log_batch` on reconnect.
  */
 
 import { connectivity, type ConnectivityState } from "./connectivity";
@@ -85,14 +72,7 @@ const IDLE_WAKE_MS = 30_000;
  */
 const PAUSE_META_KEY = "scheduler.user_paused";
 
-/**
- * Threshold for the cashier-visible "large backlog" banner. When the
- * queue depth (pending + retry) crosses this, the OfflineSyncStatus UI
- * surfaces a one-tap Pause control so the cashier can choose between
- * draining now or pausing while they take more orders. Picked at the
- * level where a sequential drain (~1-3s/entry) starts running into
- * minutes — not a hard stop, just a heads-up.
- */
+/** Queue depth at which the UI surfaces the Pause control. */
 export const LARGE_BACKLOG_THRESHOLD = 50;
 
 // ---------------------------------------------------------------------------
@@ -150,10 +130,7 @@ export class SyncScheduler {
 	 */
 	private forceOneCycle = false;
 
-	/**
-	 * Start the scheduler. Acquires the leader lock and begins the drain loop.
-	 * Idempotent. Phase 2 will call this from `Pos.vue` onMounted.
-	 */
+	/** Start the scheduler. Acquires the leader lock and begins the drain loop. Idempotent. */
 	async start(): Promise<void> {
 		if (this.running) return this.leaderAcquired ?? Promise.resolve();
 		this.running = true;
@@ -172,7 +149,7 @@ export class SyncScheduler {
 			this.userPaused = false;
 		}
 
-		// Crash-recovery (T11): a tab close / browser crash mid-drain leaves
+		// Crash-recovery: a tab close / browser crash mid-drain leaves
 		// rows stuck in `in_flight` forever — `listReady` only picks up
 		// `enqueued` and `retry_pending`. Re-arm them as enqueued on startup
 		// so the scheduler retries; server idempotency on offline_id makes
@@ -530,15 +507,7 @@ export class SyncScheduler {
 				continue;
 			}
 
-			// Cashier-set pause (Phase 1f). Idle the same way as the
-			// kill-switch branch but with `waitForWake` instead of a
-			// fixed sleep — so `resumeSync()` / `syncNow()` can wake us
-			// immediately instead of waiting up to IDLE_WAKE_MS.
-			//
-			// `forceOneCycle` is the one-shot bypass set by `syncNow()`:
-			// when set, we consume it (clear) and fall through to run
-			// one work cycle, even though `userPaused` is true. Next
-			// iteration sees forceOneCycle=false again and idles.
+			// Cashier-set pause. `forceOneCycle` is the one-shot bypass set by `syncNow()`.
 			if (this.userPaused) {
 				if (this.forceOneCycle) {
 					this.forceOneCycle = false;
@@ -554,12 +523,7 @@ export class SyncScheduler {
 				}
 			}
 
-			// Cycle preamble (Phase 1b): drain any needs_review rows that
-			// haven't yet been handed off to the server-side review queue.
-			// This heals after a transient offline window where the
-			// in-line handoff at needs_review-classification time couldn't
-			// reach the server. Idempotent on offline_id, bounded scan,
-			// non-throwing — never derails the rest of the cycle.
+			// Drain needs_review rows not yet handed off; heals after offline windows. Non-throwing.
 			try {
 				await flushPendingHandoffs();
 			} catch (err) {
@@ -567,12 +531,7 @@ export class SyncScheduler {
 				console.warn("[sync] flushPendingHandoffs threw", err);
 			}
 
-			// Vacuum (Phase 1f): poll the server for resolution status of
-			// any local `handed_off` tombstones and upgrade them when the
-			// manager has resolved or voided. Unblocks dependent children
-			// (parent_offline_ids gate, strict-closure check) without
-			// requiring a page reload. Bounded scan + non-throwing,
-			// same as the handoff flush above.
+			// Poll server for resolved/voided tombstones and upgrade local rows. Non-throwing.
 			try {
 				await vacuumTombstones();
 			} catch (err) {
@@ -580,10 +539,7 @@ export class SyncScheduler {
 				console.warn("[sync] vacuumTombstones threw", err);
 			}
 
-			// P2-D runtime config refresh + tombstone GC. Refresh first
-			// (cheap when cached) so GC uses the latest retention window.
-			// Both are non-throwing; failures here never block the work
-			// step that follows.
+			// Refresh runtime config then run tombstone GC. Both non-throwing.
 			try {
 				await refreshRuntimeConfig();
 			} catch (err) {
@@ -680,15 +636,8 @@ export class SyncScheduler {
 						result.detail,
 					);
 				} else {
-					// Phase 1b: hand off to the server-side review queue so a
-					// Sales Manager / System Manager (not the cashier) owns
-					// the fix-up workflow. We mark needs_review FIRST so the
-					// row is in a stable terminal state even if the handoff
-					// POST itself fails — the next drain cycle re-attempts
-					// the handoff via `attemptHandoff` (which only fires on
-					// `needs_review` rows). On success, the row transitions
-					// to `handed_off` (tombstone) and stops appearing in any
-					// scheduler-driven list.
+					// Mark needs_review first (stable terminal state) before attempting
+					// handoff — the next cycle retries the handoff if it fails.
 					await markNeedsReview(
 						entry.offline_id,
 						result.category,
@@ -765,11 +714,8 @@ export class SyncScheduler {
 		);
 
 		try {
-			// F7: bypass call()'s online/offline gate. The scheduler has
-			// already (a) checked connectivity at drain-loop scope, (b) carries
-			// a resolved offline.* method, and (c) has a server-shaped payload
-			// from the outbox row. Re-entering call()'s normal flow would risk
-			// re-enqueueing if connectivity flips during the send.
+			// Bypass call()'s connectivity gate; the scheduler already verified online and
+			// holds a resolved payload — re-entering the normal flow risks re-enqueueing.
 			const res = (await call({
 				method,
 				args: {
@@ -788,16 +734,9 @@ export class SyncScheduler {
 				is_background_job?: boolean;
 			};
 
-			// F6: refuse to mark "synced" if the server response represents a
-			// not-yet-final state. posapp.submit_invoice can return a draft
-			// (docstatus !== 1) when posa_allow_submissions_in_background_job
-			// is on; treating that as synced hides any later background-job
-			// failure. Idempotency makes a retry safe — the next POST returns
-			// the same name and (eventually) docstatus=1.
-			//
-			// Customer is a non-submittable doctype (docstatus always 0). The
-			// check only applies to entry types that map to submittable Frappe
-			// doctypes (invoice, opening_entry, closing_entry, material_receipt).
+			// Refuse "synced" for non-final docstatus — submit_invoice can return
+			// docstatus=0 when background submissions are enabled. Retry is safe via idempotency.
+			// Customer is non-submittable (docstatus always 0); skip the check for that type.
 			const docstatus = typeof res.docstatus === "number" ? res.docstatus : null;
 			const isSubmittableType = entry.type !== "customer";
 			if (
@@ -1031,27 +970,9 @@ type SendResult =
 // ---------------------------------------------------------------------------
 
 /**
- * Hand off a needs_review entry to the server-side
- * `POSpire Offline Sync Review` queue, then transition the local row to
- * the `handed_off` tombstone state. Idempotent on offline_id — safe to
- * call multiple times for the same entry (the server endpoint short-
- * circuits on existing offline_id and returns the same recovery row
- * name, and `markHandedOff` is itself idempotent).
- *
- * Failure modes:
- *   - Connectivity offline / detector reports not-online: skip silently.
- *     The entry stays in `needs_review`; the next online cycle calls
- *     `flushPendingHandoffs` (built into the cycle preamble below) to
- *     try again.
- *   - 5xx / network error: caught here; entry stays in `needs_review`,
- *     retried next cycle.
- *   - Validation error from the server (e.g. unknown entry_type): logged
- *     and the entry stays in `needs_review`. A real bug — the cashier
- *     can't fix it from their device, so it surfaces in the cashier's
- *     read-only tracking view as "handoff_pending" until ops investigates.
- *
- * NEVER throws — this runs as a side-effect of needs_review classification
- * and must not derail the cycle's bookkeeping.
+ * Hand off a needs_review entry to the server-side review queue, transitioning
+ * the local row to `handed_off`. Idempotent on offline_id. Skipped while offline;
+ * flushPendingHandoffs retries on the next online cycle. Never throws.
  */
 async function attemptHandoff(
 	entry: OutboxEntry<unknown>,
@@ -1068,17 +989,8 @@ async function attemptHandoff(
 		// resolved the envelope before the send attempt). We pass it
 		// straight through; the server canonicalises and hashes.
 		//
-		// CRITICAL: pin offline_id via offlineIdempotencyKey. The default
-		// path in @/utils/call generates a fresh UUID and OVERWRITES
-		// `args.offline_id` (call.ts:445-449) — the spread order puts the
-		// generated key after our args. For most writes that's correct
-		// (offline_id is the row's idempotency key), but recovery.handoff
-		// is a meta-operation: its `offline_id` arg is the FAILED ENTRY's
-		// identity, not a fresh write key. Without this pin, the OSR row
-		// gets a random UUID while the embedded payload keeps the entry's
-		// real id — and manager Retry then submits the invoice under the
-		// OSR's bogus id, leaving the closing's strict-closure check
-		// permanently looking for the entry's real id.
+		// Pin the failed entry's offline_id, not a fresh UUID — recovery.handoff
+		// uses the original id to look up the entry server-side.
 		const res = (await call({
 			method: "pospire.pospire.api.recovery.handoff",
 			intent: "write",
@@ -1149,10 +1061,7 @@ async function flushPendingHandoffs(): Promise<void> {
 		console.warn("[sync] flushPendingHandoffs: listByStatus failed", err);
 		return;
 	}
-	// Bound the scan: if a fleet of devices has hundreds of needs_review
-	// rows piled up, we don't want a single cycle to try to drain them
-	// all at once. The cycle preamble re-runs on the next iteration so
-	// the rest get picked up over time.
+	// Bound per cycle so a large backlog doesn't hog the leader.
 	for (const entry of entries.slice(0, 50)) {
 		await attemptHandoff(
 			entry,
@@ -1164,23 +1073,9 @@ async function flushPendingHandoffs(): Promise<void> {
 }
 
 /**
- * Vacuum pass for `handed_off` tombstones. Polls the server for the
- * resolution status of each local tombstone and upgrades the local row
- * when the server-side `POSpire Offline Sync Review` row has reached a
- * terminal state:
- *
- *   server `Resolved`  →  local `handed_off` → `synced` (server_doc_name
- *                          stamped from resolved_doc_name; dependent
- *                          children unblock on next gate-check).
- *   server `Voided`    →  local `handed_off` → `voided` (children stay
- *                          blocked — manager voided deliberately).
- *   server `Pending Review` / `In Review` / `Retrying`  →  no change.
- *
- * Bounded scan (100 ids per call) and skipped while offline. The
- * server endpoint is also bounded so a malicious caller can't enumerate
- * the whole queue. Runs in the cycle preamble so it picks up manager
- * actions on the natural cycle cadence (every drain wake or every
- * 30s when idle).
+ * Poll the server for resolution status of `handed_off` tombstones and upgrade
+ * local rows: Resolved → synced (unblocks dependents), Voided → voided.
+ * Bounded scan, skipped while offline.
  */
 async function vacuumTombstones(): Promise<void> {
 	if (!connectivity.isOnline()) return;
@@ -1194,16 +1089,10 @@ async function vacuumTombstones(): Promise<void> {
 	}
 	if (entries.length === 0) return;
 
-	// Cap the lookup batch — server enforces 200 max per call. We pick
-	// 100 to leave headroom and to keep the response payload small on
-	// wire-cost-sensitive deployments. Slice instead of paginating: the
-	// next cycle will pick up the rest.
+	// Cap below server's 200-id limit; next cycle picks up remainder.
 	const slice = entries.slice(0, 100);
 	const offlineIds = slice.map((e) => e.offline_id);
-	// Parallel name list: when a tombstone's OSR was created under a
-	// divergent offline_id (historical handoff identity bug), the only
-	// stable bridge to the server row is recovery_entry_name. Send both;
-	// the server prefers offline_id match and falls back to name match.
+	// Send both ids; server prefers offline_id match, falls back to name match.
 	const recoveryEntryNames = slice.map((e) => e.recovery_entry_name ?? "");
 
 	let resolutions: Record<
@@ -1235,10 +1124,7 @@ async function vacuumTombstones(): Promise<void> {
 		const remote = resolutions?.[entry.offline_id];
 		if (!remote) continue; // Server has no record — leave tombstoned.
 		if (remote.matched_by === "recovery_entry_name") {
-			// Legacy-corruption hit: the OSR row's offline_id does not match
-			// our local entry's offline_id (handoff identity bug from a prior
-			// build). The match worked by name, so resolution is sound, but
-			// log it for visibility.
+			// Matched by name fallback — log for visibility.
 			console.warn(
 				"[sync] vacuum matched tombstone via recovery_entry_name",
 				{ local_offline_id: entry.offline_id, recovery_entry_name: entry.recovery_entry_name },
@@ -1277,7 +1163,7 @@ async function vacuumTombstones(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// P2-16 / P2-17: tombstone GC + handoff stuck escalation
+// Tombstone GC + stuck handoff escalation
 // ---------------------------------------------------------------------------
 
 /**
@@ -1333,34 +1219,8 @@ async function refreshRuntimeConfig(): Promise<void> {
 	}
 }
 
-/**
- * P2-16: garbage-collect local outbox tombstones older than the
- * retention window. Deletes rows whose status ∈ {synced, voided} AND
- * whose age (since `synced_at` for synced rows, or `enqueued_at` for
- * voided rows that never got a synced_at) exceeds
- * `client_tombstone_retention_days`.
- *
- * Safe because:
- *   1. Server-side audit (Sales Invoice / Customer / etc + the recovery
- *      row's full Activity + Edits trail) is not deleted by this.
- *   2. We only delete tombstones — never anything still in flight or
- *      in needs_review. The status check is the load-bearing safety.
- *   3. Bounded scan (1000 rows per status) prevents a pathological
- *      deep history from blocking a cycle.
- *   4. Setting `client_tombstone_retention_days = 0` disables GC
- *      entirely (we no-op).
- *
- * Idempotent + safe to call from every cycle preamble. The cost is one
- * indexed scan per status when nothing to delete; deletes happen in a
- * single Dexie transaction.
- */
-/**
- * Maximum number of tombstones we'll delete in a single GC cycle.
- * Prevents the cycle preamble from doing minutes of Dexie work in
- * pathological backlog scenarios. A fleet that builds up more than
- * this in a single retention window will catch up over the next
- * several cycles — bounded but progressing.
- */
+/** Delete synced/voided outbox rows older than `client_tombstone_retention_days`. Idempotent. */
+/** Max tombstones deleted per GC cycle — prevents pathological backlog from blocking a cycle. */
 const GC_MAX_DELETIONS_PER_CYCLE = 1000;
 
 async function gcLocalTombstones(): Promise<void> {
@@ -1417,18 +1277,7 @@ async function gcLocalTombstones(): Promise<void> {
 	}
 }
 
-/**
- * P2-17: stuck-handoff escalation. Tracks per-offline-id consecutive
- * handoff failures from `attemptHandoff` and surfaces a flag on the
- * row when it crosses the threshold. The flag goes into
- * `last_error_detail` (already in the beacon projection so it lights
- * up the dashboard). We don't transition the row to a new status —
- * just decorate it so an operator can grep beacons for "STUCK_HANDOFF".
- *
- * Reset semantics: a successful handoff (markHandedOff) implicitly
- * removes the row from `needs_review`, so the in-memory counter for
- * that offline_id self-cleans on the next listByStatus iteration.
- */
+/** Tracks per-id consecutive handoff failures; decorates the row with STUCK_HANDOFF when threshold crossed. */
 const handoffFailureCounts = new Map<string, number>();
 
 function trackHandoffOutcome(offlineId: string, ok: boolean): void {
@@ -1469,18 +1318,8 @@ function trackHandoffOutcome(offlineId: string, ok: boolean): void {
 }
 
 /**
- * Boot-time migration entry point (Phase 1c).
- *
- * Called from `App.vue` after `syncScheduler.start()` so devices upgrading
- * from a pre-Phase-1b client immediately attempt to hand off any
- * needs_review rows already sitting in their local outbox — without
- * waiting for the first scheduler wake. Idempotent: rows that have
- * already been handed off are in the `handed_off` tombstone state and
- * `listByStatus("needs_review")` skips them, so calling this on every
- * boot is safe and self-healing.
- *
- * Unlike the in-cycle preamble, this returns the count of attempted
- * handoffs so the caller can log a one-line migration summary.
+ * Boot-time flush: attempt handoff for any needs_review rows already in the local outbox.
+ * Idempotent — rows already handed off are skipped. Returns attempted count.
  */
 export async function migrateLegacyNeedsReviewEntries(): Promise<{
 	attempted: number;
@@ -1525,13 +1364,10 @@ function methodForEntry(entry: OutboxEntry<unknown>): string | null {
 		case "closing_entry":
 			return "pospire.pospire.api.offline.create_closing_entry";
 		case "return":
-			// Returns are intentionally live-only in the current phase.
-			// Keep this unmapped so any stray legacy `return` row is surfaced
-			// to needs_review instead of being replayed as a partially-wired flow.
+			// Live-only; unmapped so stray rows surface to needs_review.
 			return null;
 		case "payment":
-			// Payment entries go through the online payment pipeline in v1;
-			// offline payment enqueue is not wired.
+			// Not wired for offline; goes through the online payment pipeline.
 			return null;
 		case "cash_movement":
 			return null;
@@ -1654,10 +1490,8 @@ function classifySendError(
 }
 
 /**
- * Defensively patches posting_date + owner_user into the inner `data` JSON
- * so the server's `_apply_payload_metadata` (P-5, P-11) accepts the request
- * even if the adapter at enqueue time forgot them, or the outbox row was
- * created before the adapters were fixed.
+ * Patches posting_date + owner_user into the inner `data` JSON if missing,
+ * so the server's `_apply_payload_metadata` always has them.
  */
 function patchInnerDataMetadata(
 	payload: Record<string, unknown>,
@@ -1768,15 +1602,6 @@ function errorCodeToCategory(
 	fallback: NonNullable<LastErrorCategory>,
 ): NonNullable<LastErrorCategory> {
 	if (!errorCode) return fallback;
-	// Code names match server constants in `pospire/api/offline.py`:
-	//   ERROR_PARENT_NOT_READY      = "parent_not_ready"
-	//   ERROR_SIBLINGS_NOT_READY    = "siblings_not_ready"
-	//   ERROR_STOCK_SHORTAGE        = "stock_shortage"
-	//   ERROR_BATCH_OR_SERIAL_…     = "batch_or_serial_conflict"
-	//   ERROR_ACCOUNTING_PERIOD_…   = "accounting_period_closed"
-	//   ERROR_VALIDATION            = "validation_error"
-	//   ERROR_PERMISSION            = "permission_error"
-	//   ERROR_SCHEMA_MISMATCH       = "schema_mismatch"
 	switch (errorCode) {
 		case "parent_not_ready":
 			return "parent_not_ready";
@@ -1877,21 +1702,8 @@ export async function getEntryByOfflineId(
 }
 
 // ---------------------------------------------------------------------------
-// Singleton — ONE scheduler per device.
-//
-// PHASE 2 HANDOFF: `Pos.vue` will own `scheduler.start()` / `scheduler.stop()`
-// in its `onMounted` / `onUnmounted` hooks (P-6). During Phase 1 there is no
-// component to own that lifecycle; the only caller is `main.js`-level code
-// that imports this module. We intentionally do NOT auto-start on import so
-// tests / Storybook / node harnesses can import without spinning up a drain
-// loop against a mock DB. The Phase 2 task is to:
-//
-//   import { scheduler } from "@/offline/sync";
-//   onMounted(() => { scheduler.start() });
-//   onUnmounted(() => { scheduler.stop() });
-//
-// Until then, non-pos bootstrap code should call `scheduler.start()` once
-// from its equivalent root (e.g. the Vuetify root mount in `main.js`).
+// Singleton — ONE scheduler per device. Not auto-started on import so tests
+// can import without spinning up a drain loop. Pos.vue owns start()/stop().
 // ---------------------------------------------------------------------------
 
 export const scheduler = new SyncScheduler();

--- a/frontend/src/utils/call-registry.ts
+++ b/frontend/src/utils/call-registry.ts
@@ -574,14 +574,18 @@ export const methodRegistry: Record<string, MethodConfig> = {
 				: [];
 
 			// Build the POS Closing Shift doc the offline endpoint will insert.
-			const nowIso = new Date().toISOString();
-			const todayIsoDate = nowIso.slice(0, 10);
+			// Use local time, NOT toISOString() (UTC). Frappe datetimes are
+			// site-local; mixing UTC here produces period_end_date < period_start_date
+			// on UTC-behind-local timezones (e.g. IST = UTC+5:30).
+			const _d = new Date();
+			const _p = (n: number) => String(n).padStart(2, "0");
+			const nowLocal = `${_d.getFullYear()}-${_p(_d.getMonth() + 1)}-${_p(_d.getDate())} ${_p(_d.getHours())}:${_p(_d.getMinutes())}:${_p(_d.getSeconds())}`;
+			const todayLocal = nowLocal.slice(0, 10);
 			const doc: Record<string, unknown> = {
 				doctype: "POS Closing Shift",
-				period_start_date:
-					cs.period_start_date ?? nowIso.replace("T", " ").slice(0, 19),
-				period_end_date: nowIso.replace("T", " ").slice(0, 19),
-				posting_date: cs.posting_date ?? todayIsoDate,
+				period_start_date: cs.period_start_date ?? nowLocal,
+				period_end_date: nowLocal,
+				posting_date: cs.posting_date ?? todayLocal,
 				user: cs.user ?? user,
 				pos_profile: cs.pos_profile,
 				company: cs.company,
@@ -624,6 +628,14 @@ export const methodRegistry: Record<string, MethodConfig> = {
 				ownerUser: user,
 			};
 		},
+	},
+
+	// -----------------------------------------------------------------------
+	// Shift helpers — live only (server is authoritative for submitted invoices)
+	// -----------------------------------------------------------------------
+	"pospire.pospire.api.offline.get_shift_invoice_offline_ids": {
+		intent: "read",
+		offline: false,
 	},
 
 	// -----------------------------------------------------------------------

--- a/pospire/pospire/api/offline.py
+++ b/pospire/pospire/api/offline.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import frappe
 from frappe import _
-from frappe.utils import cint, get_datetime, now
+from frappe.utils import cint, flt, get_datetime, now
 
 # ---------------------------------------------------------------------------
 # Error taxonomy (see docs/offline/12-server-side-changes.md §5)
@@ -461,6 +461,51 @@ def get_offline_flags_for_shift(opening_shift_name: str) -> dict[str, int]:
 			snapshot.get("pos_profile_snapshot_allow_add_to_stock_at_pos") or 0
 		),
 	}
+
+
+@frappe.whitelist()
+def get_shift_invoice_offline_ids(
+	opening_shift_name: str | None = None,
+	opening_shift_offline_id: str | None = None,
+) -> list[str]:
+	"""Return pos_offline_id values for all submitted invoices on a shift.
+
+	Mirrors the two-path query in _ensure_all_invoices_submitted so the frontend
+	can include server-submitted invoices in the closing payload's invoice_offline_ids,
+	preventing strict-closure retries from waiting on invoices that are already
+	submitted on the server.
+
+	Returns only non-null pos_offline_id values (invoices without one are not
+	checked by strict closure and don't need to be listed).
+	"""
+	return sorted(_get_submitted_shift_invoice_offline_ids(opening_shift_name, opening_shift_offline_id))
+
+
+def _get_submitted_shift_invoice_offline_ids(
+	opening_shift_name: str | None = None,
+	opening_shift_offline_id: str | None = None,
+) -> set[str]:
+	"""Return submitted Sales Invoice offline IDs linked to a POS shift."""
+	ids: set[str] = set()
+	if opening_shift_name:
+		for x in frappe.get_all(
+			"Sales Invoice",
+			filters={"posa_pos_opening_shift": opening_shift_name, "docstatus": 1},
+			pluck="pos_offline_id",
+		):
+			if x:
+				ids.add(x)
+
+	if opening_shift_offline_id:
+		for x in frappe.get_all(
+			"Sales Invoice",
+			filters={"pos_opening_shift_offline_id": opening_shift_offline_id, "docstatus": 1},
+			pluck="pos_offline_id",
+		):
+			if x:
+				ids.add(x)
+
+	return ids
 
 
 # ---------------------------------------------------------------------------
@@ -1511,19 +1556,22 @@ def _ensure_all_invoices_submitted(
 	opening_ref: str,
 	invoice_offline_ids: list[str],
 	opening_offline_id: str | None = None,
-) -> str:
+) -> tuple[str, list[str], list[str]]:
 	"""Strict-closure precondition for offline closing entries (§4.4, P-8).
 
 	Two-part check:
 	  (a) every offline id the client lists maps to a submitted Sales Invoice;
-	  (b) no orphan Sales Invoice exists on the server under this shift that
-	      the client forgot to list.
-	Both must hold before we accept a closing entry.
+	  (b) every already-submitted Sales Invoice linked to the shift is folded
+	      into the canonical sibling list, including online-before-offline
+	      invoices omitted by older closing payloads.
 
-	`opening_ref` is the REAL shift name (post-resolution). `opening_offline_id`
-	is the optional UUID that lets the orphan check also catch invoices that
-	reference the shift via `pos_opening_shift_offline_id` (offline-queued
-	invoices created before the shift's offline_id was rewritten).
+	`opening_ref` is the REAL shift name (post-resolution).
+	`opening_offline_id` is the optional UUID that lets the server-side
+	enrichment also catch invoices that reference the shift via
+	`pos_opening_shift_offline_id` (offline-queued invoices created before the
+	shift's offline_id was rewritten).
+
+	Returns `(opening_name, canonical_invoice_offline_ids, auto_included_ids)`.
 	"""
 	# Resolved name is supplied by the caller now; the previous in-line
 	# offline-only lookup didn't support online-opened shifts.
@@ -1547,15 +1595,20 @@ def _ensure_all_invoices_submitted(
 				{"missing_offline_ids": missing_on_server},
 			)
 
-	# Orphan check: every SUBMITTED Sales Invoice tied to this shift on the
-	# server must appear in the client's list. A mismatch means the client's
-	# outbox view of the shift is incomplete.
+	# Server-side enrichment: every SUBMITTED Sales Invoice tied to this
+	# shift is already safe for closing dependency purposes, even if an older
+	# offline payload omitted it from `invoice_offline_ids` because it was
+	# created online before the device went offline. We add those IDs to the
+	# canonical set instead of requiring a manager to edit historical OSR
+	# payloads by hand.
 	#
 	# Mixed-mode shifts can have invoices linked via EITHER:
 	#   - `posa_pos_opening_shift = <real name>` (online-opened OR resolved)
 	#   - `pos_opening_shift_offline_id = <UUID>` (offline-queued, before
 	#     opening sync rewrote the link).
-	# Run both checks; union the results.
+	# Run both checks; union the results. This does not weaken the important
+	# sibling gate above: any invoice ID explicitly listed by the client still
+	# must map to a submitted Sales Invoice before the close can proceed.
 	#
 	# `docstatus=1` filter is correctness AND performance:
 	#   1. Cancelled (docstatus=2) and drafts (docstatus=0) are not siblings
@@ -1563,42 +1616,187 @@ def _ensure_all_invoices_submitted(
 	#   2. The B1 compound index
 	#      `pospire_strict_closure_idx (pos_opening_shift_offline_id, docstatus)`
 	#      satisfies the offline-id query from the index alone.
-	orphans: set[str] = set()
+	declared_ids = set(cleaned)
+	server_submitted_ids = _get_submitted_shift_invoice_offline_ids(
+		opening_name,
+		opening_offline_id,
+	)
+	auto_included_ids = sorted(server_submitted_ids - declared_ids)
+	canonical_invoice_ids = sorted(declared_ids | server_submitted_ids)
 
-	# Online-link orphans (posa_pos_opening_shift = real shift name).
-	online_filters: dict[str, Any] = {
-		"posa_pos_opening_shift": opening_name,
-		"docstatus": 1,
-	}
-	if cleaned:
-		online_filters["pos_offline_id"] = ["not in", cleaned]
-	for x in frappe.get_all("Sales Invoice", filters=online_filters, pluck="pos_offline_id"):
-		if x:
-			orphans.add(x)
+	return opening_name, canonical_invoice_ids, auto_included_ids
 
-	# Offline-link orphans (pos_opening_shift_offline_id = UUID). Only
-	# applicable when we have an offline_id to query by.
+
+def _aggregate_closing_from_invoices(
+	opening_name: str,
+	pos_profile_name: str | None,
+	opening_offline_id: str | None = None,
+) -> dict[str, Any]:
+	"""Aggregate invoice-derived fields for a POS Closing Shift.
+
+	Returns a dict with keys: pos_transactions, taxes, pos_payments,
+	grand_total, net_total, total_quantity, pay_expected (mop → amount).
+	pay_expected is seeded from the opening shift balance_details (opening
+	cash in drawer) then invoice payments are added on top — matching the
+	live builder in make_closing_shift_from_opening.
+	"""
+	cash_mode = (
+		frappe.get_cached_value("POS Profile", pos_profile_name, "posa_cash_mode_of_payment")
+		if pos_profile_name
+		else None
+	) or "Cash"
+
+	# Seed pay_expected from opening balance (mirrors live builder line 209-218).
+	pay_expected: dict[str, float] = {}
+	for bd in frappe.get_all(
+		"POS Opening Shift Detail",
+		filters={"parent": opening_name},
+		fields=["mode_of_payment", "amount"],
+	):
+		pay_expected[bd.mode_of_payment] = flt(bd.amount)
+
+	# Collect invoice names from both link paths (mirrors _ensure_all_invoices_submitted).
+	inv_names: set[str] = set()
+	for row in frappe.get_all(
+		"Sales Invoice",
+		filters={"posa_pos_opening_shift": opening_name, "docstatus": 1},
+		pluck="name",
+	):
+		inv_names.add(row)
 	if opening_offline_id:
-		offline_filters: dict[str, Any] = {
-			"pos_opening_shift_offline_id": opening_offline_id,
-			"docstatus": 1,
-		}
-		if cleaned:
-			offline_filters["pos_offline_id"] = ["not in", cleaned]
-		for x in frappe.get_all("Sales Invoice", filters=offline_filters, pluck="pos_offline_id"):
-			if x:
-				orphans.add(x)
+		for row in frappe.get_all(
+			"Sales Invoice",
+			filters={"pos_opening_shift_offline_id": opening_offline_id, "docstatus": 1},
+			pluck="name",
+		):
+			inv_names.add(row)
 
-	if orphans:
-		_throw(
-			ERROR_SIBLINGS_NOT_READY,
-			_("Cannot close: shift has invoices not listed in closing payload: {0}").format(
-				", ".join(sorted(orphans))
-			),
-			{"unlisted_offline_ids": sorted(orphans)},
+	invoices = (
+		frappe.get_all(
+			"Sales Invoice",
+			filters={"name": ["in", sorted(inv_names)]},
+			fields=[
+				"name",
+				"posting_date",
+				"grand_total",
+				"net_total",
+				"total_qty",
+				"customer",
+				"change_amount",
+			],
 		)
+		if inv_names
+		else []
+	)
 
-	return opening_name
+	pos_transactions: list[dict] = []
+	taxes: list[dict] = []
+	grand_total = 0.0
+	net_total = 0.0
+	total_quantity = 0.0
+
+	for inv in invoices:
+		pos_transactions.append(
+			{
+				"sales_invoice": inv.name,
+				"posting_date": inv.posting_date,
+				"grand_total": inv.grand_total,
+				"customer": inv.customer,
+			}
+		)
+		grand_total += flt(inv.grand_total)
+		net_total += flt(inv.net_total)
+		total_quantity += flt(inv.total_qty)
+
+		for t in frappe.get_all(
+			"Sales Taxes and Charges",
+			filters={"parent": inv.name},
+			fields=["account_head", "rate", "tax_amount"],
+		):
+			existing = next(
+				(tx for tx in taxes if tx["account_head"] == t.account_head and tx["rate"] == t.rate),
+				None,
+			)
+			if existing:
+				existing["amount"] += flt(t.tax_amount)
+			else:
+				taxes.append({"account_head": t.account_head, "rate": t.rate, "amount": flt(t.tax_amount)})
+
+		for p in frappe.get_all(
+			"Sales Invoice Payment",
+			filters={"parent": inv.name},
+			fields=["mode_of_payment", "amount"],
+		):
+			amount = flt(p.amount)
+			if p.mode_of_payment == cash_mode:
+				amount -= flt(inv.change_amount)
+			pay_expected[p.mode_of_payment] = pay_expected.get(p.mode_of_payment, 0.0) + amount
+
+	pos_payments: list[dict] = []
+	for py in frappe.get_all(
+		"Payment Entry",
+		filters={"docstatus": 1, "reference_no": opening_name, "payment_type": "Receive"},
+		fields=["name", "mode_of_payment", "paid_amount", "posting_date", "party"],
+	):
+		pos_payments.append(
+			{
+				"payment_entry": py.name,
+				"mode_of_payment": py.mode_of_payment,
+				"paid_amount": py.paid_amount,
+				"posting_date": py.posting_date,
+				"customer": py.party,
+			}
+		)
+		pay_expected[py.mode_of_payment] = pay_expected.get(py.mode_of_payment, 0.0) + flt(py.paid_amount)
+
+	return {
+		"pos_transactions": pos_transactions,
+		"taxes": taxes,
+		"pos_payments": pos_payments,
+		"grand_total": grand_total,
+		"net_total": net_total,
+		"total_quantity": total_quantity,
+		"pay_expected": pay_expected,
+	}
+
+
+def _enrich_closing_payload(
+	payload: dict[str, Any], opening_name: str, opening_offline_id: str | None = None
+) -> None:
+	"""Overwrite invoice-derived fields on an offline closing payload.
+
+	Preserves cashier-entered fields (closing_amount, denomination_details,
+	period dates, user, company, pos_profile). Recomputes everything that
+	must come from submitted server records.
+	"""
+	pos_profile_name = payload.get("pos_profile") or frappe.db.get_value(
+		"POS Opening Shift", opening_name, "pos_profile"
+	)
+	agg = _aggregate_closing_from_invoices(opening_name, pos_profile_name, opening_offline_id)
+
+	payload["pos_transactions"] = agg["pos_transactions"]
+	payload["taxes"] = agg["taxes"]
+	payload["pos_payments"] = agg["pos_payments"]
+	payload["grand_total"] = agg["grand_total"]
+	payload["net_total"] = agg["net_total"]
+	payload["total_quantity"] = agg["total_quantity"]
+
+	pay_expected = agg["pay_expected"]
+	existing_recon = payload.get("payment_reconciliation") or []
+	seen_mops: set[str] = set()
+	new_recon: list[dict] = []
+	for row in existing_recon:
+		if not isinstance(row, dict):
+			continue
+		mop = row.get("mode_of_payment")
+		new_recon.append({**row, "expected_amount": pay_expected.get(mop, 0.0)})
+		seen_mops.add(mop)
+	for mop, exp in pay_expected.items():
+		if mop not in seen_mops:
+			new_recon.append(
+				{"mode_of_payment": mop, "opening_amount": 0, "expected_amount": exp, "closing_amount": 0}
+			)
+	payload["payment_reconciliation"] = new_recon
 
 
 @frappe.whitelist()
@@ -1652,14 +1850,34 @@ def create_closing_entry(
 		)
 
 	opening_name, opening_offline_id = _resolve_opening_shift_flexible(ref)
-	_ensure_all_invoices_submitted(
+	(
+		opening_name,
+		canonical_invoice_offline_ids,
+		auto_included_invoice_offline_ids,
+	) = _ensure_all_invoices_submitted(
 		opening_name,
 		invoice_offline_ids,
 		opening_offline_id=opening_offline_id,
 	)
 	payload["pos_opening_shift"] = opening_name
+	_enrich_closing_payload(payload, opening_name, opening_offline_id)
 
-	return _idempotent_submit(
+	# If a draft exists from a prior partial replay, patch it with the
+	# enriched payload before _idempotent_submit resumes submission — the
+	# draft branch submits the existing doc as-is without re-applying fields.
+	existing_draft_name = frappe.db.get_value(
+		"POS Closing Shift", {"pos_offline_id": offline_id, "docstatus": 0}, "name"
+	)
+	if existing_draft_name:
+		draft = frappe.get_doc("POS Closing Shift", existing_draft_name)
+		for field in ("pos_transactions", "taxes", "pos_payments", "payment_reconciliation"):
+			draft.set(field, payload.get(field, []))
+		for field in ("grand_total", "net_total", "total_quantity"):
+			draft.set(field, payload.get(field, 0))
+		draft.flags.ignore_permissions = True
+		draft.save()
+
+	result = _idempotent_submit(
 		"POS Closing Shift",
 		payload,
 		offline_id,
@@ -1667,6 +1885,10 @@ def create_closing_entry(
 		submit=True,
 		owner_user=owner_user,
 	)
+	if auto_included_invoice_offline_ids:
+		result["auto_included_invoice_offline_ids"] = auto_included_invoice_offline_ids
+		result["validated_invoice_offline_ids"] = canonical_invoice_offline_ids
+	return result
 
 
 @frappe.whitelist()
@@ -2016,6 +2238,7 @@ __all__ = [
 	"create_material_receipt",
 	"create_opening_entry",
 	"get_offline_flags_for_shift",
+	"get_shift_invoice_offline_ids",
 	"log_batch",
 	"ping",
 	"snapshot_profile_flags_onto_opening_shift",

--- a/pospire/pospire/api/posapp.py
+++ b/pospire/pospire/api/posapp.py
@@ -43,6 +43,7 @@ from erpnext.stock.doctype.batch.batch import (
 	get_batch_qty,
 )
 from erpnext.stock.get_item_details import get_item_details
+from erpnext.stock.stock_ledger import NegativeStockError
 from frappe import _
 from frappe.query_builder import Field
 from frappe.query_builder.functions import IfNull
@@ -675,7 +676,9 @@ def update_invoice(data: str | dict):
 
 		# Step 1: Handle accounting dimensions (custom + standard)
 		try:
-			accounting_dimensions = get_accounting_dimensions(as_list=False, filters={"disabled": 0})
+			# ERPNext v16's get_accounting_dimensions() already filters disabled
+			# dimensions and no longer accepts a `filters` kwarg.
+			accounting_dimensions = get_accounting_dimensions(as_list=False)
 			accounting_dimensions_fields = [d.fieldname for d in accounting_dimensions]
 
 			# Include standard dimensions
@@ -1024,7 +1027,10 @@ def submit_invoice(invoice: str | dict, data: str | dict, offline_id: str | None
 				},
 			)
 	else:
-		invoice_doc.submit()
+		try:
+			invoice_doc.submit()
+		except NegativeStockError as e:
+			frappe.throw(str(e), title=_("Insufficient Stock"))
 		if invoice_doc.is_return and invoice_doc.return_against and not is_cashback:
 			original_invoice = frappe.get_doc("Sales Invoice", invoice_doc.return_against)
 			custom_delivery_charge = flt(original_invoice.get("custom_delivery_charge_rate") or 0)

--- a/pospire/pospire/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/pospire/pospire/doctype/pos_closing_shift/pos_closing_shift.py
@@ -333,6 +333,22 @@ def make_closing_shift_from_opening(opening_shift: str | dict):
 @frappe.whitelist()
 def submit_closing_shift(closing_shift: str | dict) -> str:
 	closing_shift = _load(closing_shift)
+
+	opening_shift = closing_shift.get("pos_opening_shift") if isinstance(closing_shift, dict) else None
+	if opening_shift:
+		existing = frappe.db.get_value(
+			"POS Closing Shift",
+			{"pos_opening_shift": opening_shift, "docstatus": 1},
+			"name",
+		)
+		if existing:
+			opening_doc = frappe.get_doc("POS Opening Shift", opening_shift)
+			if opening_doc.pos_closing_shift != existing or opening_doc.status == "Open":
+				opening_doc.pos_closing_shift = existing
+				opening_doc.set_status()
+				opening_doc.save()
+			return existing
+
 	closing_shift_doc = frappe.get_doc(closing_shift)
 	closing_shift_doc.flags.ignore_permissions = True
 	closing_shift_doc.save()

--- a/pospire/pospire/tests/test_offline.py
+++ b/pospire/pospire/tests/test_offline.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 from contextlib import suppress
+from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
@@ -34,12 +35,16 @@ from pospire.pospire.api.offline import (
 	ERROR_ACCOUNTING_PERIOD_CLOSED,
 	ERROR_PARENT_NOT_READY,
 	ERROR_PERMISSION,
+	ERROR_SIBLINGS_NOT_READY,
 	ERROR_VALIDATION,
 	OfflineSubmitError,
 	_acting_as_user,
+	_aggregate_closing_from_invoices,
 	_apply_payload_metadata,
 	_assert_offline_action_allowed_by_shift,
 	_check_accounting_period_open,
+	_enrich_closing_payload,
+	_ensure_all_invoices_submitted,
 	_existing_by_offline_id,
 	_idempotent_submit,
 	_resolve_opening_shift,
@@ -58,6 +63,7 @@ from pospire.pospire.tests.test_utils import (
 # must use this generator for offline_id values.
 _UUID_VALID = "12345678-1234-4abc-9def-0123456789ab"
 _UUID_VALID_2 = "abcdef01-2345-4abc-89cd-0123456789ab"
+_UUID_VALID_3 = "fedcba98-7654-4abc-89cd-0123456789ab"
 
 
 def _make_offline_id() -> str:
@@ -98,6 +104,150 @@ class TestResolvers(FrappeTestCase):
 		real shift name."""
 		with self.assertRaises(OfflineSubmitError):
 			_resolve_opening_shift_flexible("POSA-OS-26-DOESNOTEXIST")
+
+
+# ---------------------------------------------------------------------------
+# Strict closure — P-8 server-side sibling validation
+# ---------------------------------------------------------------------------
+
+
+class TestStrictClosureValidation(FrappeTestCase):
+	"""Strict closure accepts already-submitted server siblings omitted by
+	older payloads, while still blocking declared siblings that are not yet
+	submitted."""
+
+	def test_auto_includes_submitted_shift_invoices_omitted_from_payload(self):
+		"""Online-before-offline invoices are server-submitted siblings. They
+		should not force managers to hand-edit historical OSR payloads."""
+
+		def fake_get_all(doctype, filters=None, pluck=None, **kwargs):
+			filters = filters or {}
+			self.assertEqual(doctype, "Sales Invoice")
+			if filters.get("pos_offline_id"):
+				return [_UUID_VALID]
+			if filters.get("posa_pos_opening_shift") == "POSA-OS-26-0000041":
+				return [_UUID_VALID, _UUID_VALID_2]
+			return []
+
+		with patch("pospire.pospire.api.offline.frappe.get_all", side_effect=fake_get_all):
+			opening_name, canonical_ids, auto_included_ids = _ensure_all_invoices_submitted(
+				"POSA-OS-26-0000041",
+				[_UUID_VALID],
+			)
+
+		self.assertEqual(opening_name, "POSA-OS-26-0000041")
+		self.assertEqual(canonical_ids, sorted([_UUID_VALID, _UUID_VALID_2]))
+		self.assertEqual(auto_included_ids, [_UUID_VALID_2])
+
+	def test_declared_invoice_must_still_be_submitted(self):
+		"""Auto-inclusion only covers submitted server siblings; explicitly
+		listed invoice IDs still block the close until they submit."""
+
+		def fake_get_all(doctype, filters=None, pluck=None, **kwargs):
+			filters = filters or {}
+			self.assertEqual(doctype, "Sales Invoice")
+			if filters.get("pos_offline_id"):
+				return []
+			if filters.get("posa_pos_opening_shift") == "POSA-OS-26-0000041":
+				return [_UUID_VALID_2]
+			return []
+
+		with patch("pospire.pospire.api.offline.frappe.get_all", side_effect=fake_get_all):
+			with self.assertRaises(OfflineSubmitError):
+				_ensure_all_invoices_submitted("POSA-OS-26-0000041", [_UUID_VALID_3])
+		self.assertEqual(frappe.local.response.get("error_code"), ERROR_SIBLINGS_NOT_READY)
+
+
+# ---------------------------------------------------------------------------
+# Closing enrichment — _aggregate_closing_from_invoices / _enrich_closing_payload
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichClosingPayload(FrappeTestCase):
+	"""_enrich_closing_payload builds correct totals from submitted invoices."""
+
+	def test_opening_balance_seeded_into_expected_amount(self):
+		"""pay_expected starts from the opening shift balance, then adds invoice
+		payments — so expected cash = opening_cash + invoice_cash_sales."""
+
+		def fake_get_all(doctype, filters=None, pluck=None, fields=None, **kwargs):
+			filters = filters or {}
+			if doctype == "POS Opening Shift Detail":
+				return [frappe._dict({"mode_of_payment": "Cash", "amount": 5000})]
+			if doctype == "Sales Invoice" and pluck == "name":
+				return ["INV-001"] if filters.get("posa_pos_opening_shift") else []
+			if doctype == "Sales Invoice":
+				return [
+					frappe._dict(
+						name="INV-001",
+						posting_date="2026-05-15",
+						grand_total=2075,
+						net_total=2075,
+						total_qty=3,
+						customer="Test Customer",
+						change_amount=0,
+					)
+				]
+			if doctype == "Sales Invoice Payment":
+				return [frappe._dict({"mode_of_payment": "Cash", "amount": 2075})]
+			if doctype == "Sales Taxes and Charges":
+				return []
+			if doctype == "Payment Entry":
+				return []
+			return []
+
+		with (
+			patch("pospire.pospire.api.offline.frappe.get_all", side_effect=fake_get_all),
+			patch("pospire.pospire.api.offline.frappe.get_cached_value", return_value=None),
+			patch("pospire.pospire.api.offline.frappe.db.get_value", return_value=None),
+		):
+			agg = _aggregate_closing_from_invoices("POSA-OS-TEST", None)
+
+		self.assertAlmostEqual(agg["pay_expected"]["Cash"], 7075.0)
+		self.assertAlmostEqual(agg["grand_total"], 2075.0)
+		self.assertEqual(len(agg["pos_transactions"]), 1)
+
+	def test_invoice_via_offline_link_included_in_aggregation(self):
+		"""Invoices linked only by pos_opening_shift_offline_id are aggregated —
+		matches the two-path lookup used by strict closure."""
+		offline_uuid = _UUID_VALID
+
+		def fake_get_all(doctype, filters=None, pluck=None, fields=None, **kwargs):
+			filters = filters or {}
+			if doctype == "POS Opening Shift Detail":
+				return []
+			if doctype == "Sales Invoice" and pluck == "name":
+				if filters.get("posa_pos_opening_shift"):
+					return []
+				if filters.get("pos_opening_shift_offline_id") == offline_uuid:
+					return ["INV-OFFLINE-001"]
+				return []
+			if doctype == "Sales Invoice":
+				return [
+					frappe._dict(
+						name="INV-OFFLINE-001",
+						posting_date="2026-05-15",
+						grand_total=500,
+						net_total=500,
+						total_qty=1,
+						customer="Test Customer",
+						change_amount=0,
+					)
+				]
+			if doctype in ("Sales Invoice Payment", "Sales Taxes and Charges", "Payment Entry"):
+				return []
+			return []
+
+		with (
+			patch("pospire.pospire.api.offline.frappe.get_all", side_effect=fake_get_all),
+			patch("pospire.pospire.api.offline.frappe.get_cached_value", return_value=None),
+			patch("pospire.pospire.api.offline.frappe.db.get_value", return_value=None),
+		):
+			agg = _aggregate_closing_from_invoices("POSA-OS-TEST", None, opening_offline_id=offline_uuid)
+
+		self.assertAlmostEqual(agg["grand_total"], 500.0)
+		self.assertEqual(len(agg["pos_transactions"]), 1)
+		self.assertEqual(agg["pos_transactions"][0]["sales_invoice"], "INV-OFFLINE-001")
 
 
 # ---------------------------------------------------------------------------
@@ -548,6 +698,7 @@ class TestModuleSurface(FrappeTestCase):
 			"get_observability_summary",
 			"snapshot_profile_flags_onto_opening_shift",
 			"get_offline_flags_for_shift",
+			"get_shift_invoice_offline_ids",
 		]
 		for name in expected:
 			self.assertTrue(

--- a/pospire/public/js/posapp/components/pos/Pos.vue
+++ b/pospire/public/js/posapp/components/pos/Pos.vue
@@ -72,6 +72,8 @@ export default {
 			pendingProfileData: null,
 			pendingMasterDataRefresh: { items: false, customers: false },
 			cartHasItems: false,
+			subscribedMasterDataRoom: false,
+			subscribedProfileName: null,
 		};
 	},
 
@@ -100,6 +102,7 @@ export default {
 				.then((r) => {
 					if (r.message) {
 						this.pos_profile = r.message.pos_profile;
+						this.subscribe_to_pos_realtime_rooms(this.pos_profile.name);
 						this.pos_opening_shift = r.message.pos_opening_shift;
 						this.get_offers(this.pos_profile.name);
 						this.eventBus.emit("register_pos_profile", r.message);
@@ -163,10 +166,39 @@ export default {
 				this.eventBus.emit("set_pos_settings", doc);
 			});
 		},
+		subscribe_to_pos_realtime_rooms(profileName) {
+			if (!frappe.realtime) return;
+
+			if (!this.subscribedMasterDataRoom) {
+				frappe.realtime.doctype_subscribe("POS Profile");
+				this.subscribedMasterDataRoom = true;
+			}
+
+			if (!profileName || this.subscribedProfileName === profileName) return;
+
+			if (this.subscribedProfileName) {
+				frappe.realtime.doc_unsubscribe("POS Profile", this.subscribedProfileName);
+			}
+			frappe.realtime.doc_subscribe("POS Profile", profileName);
+			this.subscribedProfileName = profileName;
+		},
+		unsubscribe_from_pos_realtime_rooms() {
+			if (!frappe.realtime) return;
+
+			if (this.subscribedProfileName) {
+				frappe.realtime.doc_unsubscribe("POS Profile", this.subscribedProfileName);
+				this.subscribedProfileName = null;
+			}
+			if (this.subscribedMasterDataRoom) {
+				frappe.realtime.doctype_unsubscribe("POS Profile");
+				this.subscribedMasterDataRoom = false;
+			}
+		},
 	},
 
 	mounted: function () {
 		this.$nextTick(function () {
+			this.subscribe_to_pos_realtime_rooms();
 			this.check_opening_entry();
 			this.get_pos_setting();
 			this.eventBus.on("close_opening_dialog", () => {
@@ -174,6 +206,7 @@ export default {
 			});
 			this.eventBus.on("register_pos_data", (data) => {
 				this.pos_profile = data.pos_profile;
+				this.subscribe_to_pos_realtime_rooms(this.pos_profile.name);
 				this.get_offers(this.pos_profile.name);
 				this.pos_opening_shift = data.pos_opening_shift;
 				this.eventBus.emit("register_pos_profile", data);
@@ -257,6 +290,7 @@ export default {
 						.then((r) => {
 							if (!r.message) return;
 							this.pos_profile = r.message.pos_profile;
+							this.subscribe_to_pos_realtime_rooms(this.pos_profile.name);
 							if (!this.cartHasItems) {
 								this.get_offers(r.message.pos_profile.name);
 								this.eventBus.emit("register_pos_profile", r.message);
@@ -312,6 +346,7 @@ export default {
 		this.eventBus.off("load_return_invoice");
 		this.eventBus.off("clear_invoice");
 		this.eventBus.off("cart_emptied");
+		this.unsubscribe_from_pos_realtime_rooms();
 		frappe.realtime.off("pos_profile_updated");
 		frappe.realtime.off("pos_master_data_invalidated");
 	},


### PR DESCRIPTION
## Summary

- **Server-side closing enrichment**: `_enrich_closing_payload` rebuilds invoice totals, payment expected amounts, and POS transactions from submitted invoices at sync time, fixing empty closing shift records when the shift was closed offline and synced later.
- **Auto-include submitted invoices**: `_ensure_all_invoices_submitted` now folds in already-submitted invoices that older closing payloads missed (online-before-offline flow), eliminating the OSR retry loop for mixed-mode shifts.
- **Idempotent close**: `submit_closing_shift` returns the existing closing name if a submitted one already exists for the shift, and repairs the opening shift status if it was left stale.
- **NegativeStockError + accounting dimensions**: Online invoice submit now catches `NegativeStockError` with a user-facing message; `get_accounting_dimensions` call fixed for ERPNext v16 (removed `filters=` kwarg).
- **Snapshot reload safety**: `register_pos_data` now persists the opening snapshot on every shift open (online or provisional offline), so the offline-open guard in OpeningDialog always has `pos_profile` + `company`; `invalidateOpeningSnapshot` preserves those fields; provisional shifts are not wiped by a server returning no-shift while sync is pending.
- **Timezone fix**: Closing `period_end_date` uses local datetime formatting instead of `toISOString()` UTC to match Frappe's local-timezone storage.

## Test plan

- [ ] Online open → offline invoices → offline close → reopen offline: no "recent online session" warning
- [ ] Online open → offline close queued → page reload before sync: cashier stays in POS on provisional shift
- [ ] Mixed-mode shift (online + offline invoices): closing enriched with correct totals on sync
- [ ] Duplicate close (already submitted): second `submit_closing_shift` call returns existing name, no error
- [ ] Negative stock item online submit: shows user-facing error instead of 417
- [ ] `bench run-tests --app pospire --module pospire.pospire.tests.test_offline`