### PR TITLE
supporting barcodes in pospire

### DIFF
--- a/frontend/src/components/pos/ItemsSelector.vue
+++ b/frontend/src/components/pos/ItemsSelector.vue
@@ -465,6 +465,19 @@ export default {
 		new_line() {
 			this.eventBus.emit("set_new_line", this.new_line);
 		},
+		/**
+		 * Mirrors trigger_onscan(): auto-add on any exact barcode/serial/batch
+		 * match so typed or pasted codes work without pressing Enter, same as
+		 * a hardware scanner. enter_event() itself no-ops unless it finds an
+		 * exact match, and clears first_search on a successful add, so this
+		 * can't loop or double-fire on partial/in-progress input.
+		 */
+		first_search(newValue) {
+			if (!newValue) {
+				return;
+			}
+			this.enter_event();
+		},
 	},
 
 	methods: {

--- a/frontend/src/components/pos/ItemsSelector.vue
+++ b/frontend/src/components/pos/ItemsSelector.vue
@@ -1124,7 +1124,6 @@ export default {
 }
 
 /*
- * Scrollable areas for items list/grid
  * Height is handled by flexbox - DO NOT use viewport calc here!
  */
 .items-grid-scroll,


### PR DESCRIPTION
Adds a watcher on first_search so typed or pasted barcodes, serial numbers, and batch numbers are added to the cart automatically, the same way a hardware scanner already works. Previously this required pressing Enter.
The watcher calls the existing enter_event()`— no new matching logic. It only fires on a genuine exact match and safely resets without double-firing on partial input or repeated triggers.