### PR TITLE
fix(offline): shift lifecycle — opening dialog config and stuck-open shifts

### DIFF
--- a/frontend/__tests__/utils/call-transport.test.ts
+++ b/frontend/__tests__/utils/call-transport.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Transport tests for `@/utils/call`'s `liveFetch` (task-11).
+ *
+ * `liveFetch` is module-private by design — these tests drive it exclusively
+ * through the exported `call()`, using `pospire.pospire.api.offline.ping`
+ * (`{ intent: "read", offline: false }` in call-registry.ts) so the read path
+ * has no cache and no offline fallback to get in the way: a live 2xx returns
+ * the raw `message` body, and a live failure rejects straight out of `call()`.
+ *
+ * Why this file exists at all: the plan's global "no new tests" rule is
+ * explicitly overridden for this task only (see task-11-brief.md). `call.ts`
+ * now performs its own `fetch()` instead of delegating to frappe-ui, and
+ * there is no TypeScript compiler in this project to catch a shape mistake
+ * in that rewrite — these five cases are the only real gate on it.
+ *
+ * Each test does its own `vi.resetModules()` + dynamic import (matching
+ * `connectivity.test.ts`'s convention) so the connectivity module's
+ * module-level state — and any async reachability ping a 5xx report can
+ * kick off (see connectivity.ts `reportRequestOutcome`) — never bleeds
+ * across tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const METHOD = "pospire.pospire.api.offline.ping";
+
+beforeEach(() => {
+	vi.resetModules();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+	delete (window as unknown as { csrf_token?: string }).csrf_token;
+});
+
+async function importFresh() {
+	const { call } = await import("@/utils/call");
+	const { connectivity } = await import("@/offline/connectivity");
+	return { call, connectivity };
+}
+
+/** A resolved-fetch stand-in. Only the members `liveFetch` touches are set. */
+function fakeResponse(opts: {
+	status: number;
+	ok?: boolean;
+	jsonBody?: unknown;
+	textBody?: string;
+}): Response {
+	const ok = opts.ok ?? (opts.status >= 200 && opts.status < 300);
+	const text = opts.textBody ?? JSON.stringify(opts.jsonBody ?? {});
+	return {
+		ok,
+		status: opts.status,
+		json: async () => opts.jsonBody,
+		text: async () => text,
+	} as Response;
+}
+
+function setCsrfToken(value: string | undefined) {
+	if (value === undefined) {
+		delete (window as unknown as { csrf_token?: string }).csrf_token;
+	} else {
+		(window as unknown as { csrf_token?: string }).csrf_token = value;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 1. Request shape
+// ---------------------------------------------------------------------------
+
+describe("liveFetch request shape", () => {
+	it("posts to /api/method/<method> with frappe-ui's headers/body and gates the CSRF header on a real token", async () => {
+		const { call } = await importFresh();
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(fakeResponse({ status: 200, jsonBody: { message: { ok: true } } }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		setCsrfToken("a-real-csrf-token");
+		await call({ method: METHOD, args: { foo: "bar" }, intent: "read" });
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe(`/api/method/${METHOD}`);
+		expect(init.method).toBe("POST");
+		expect(init.headers).toMatchObject({
+			Accept: "application/json",
+			"Content-Type": "application/json; charset=utf-8",
+			"X-Frappe-Site-Name": window.location.hostname,
+			"X-Frappe-CSRF-Token": "a-real-csrf-token",
+		});
+		expect(init.body).toBe(JSON.stringify({ foo: "bar" }));
+
+		// The unrendered placeholder must NOT produce a CSRF header — sending
+		// the literal string would look like a (bogus) token to the server.
+		fetchMock.mockClear();
+		setCsrfToken("{{ csrf_token }}");
+		await call({ method: METHOD, args: { foo: "bar" }, intent: "read" });
+		const [, init2] = fetchMock.mock.calls[0] as [string, RequestInit];
+		expect(init2.headers).not.toHaveProperty("X-Frappe-CSRF-Token");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 2. Success
+// ---------------------------------------------------------------------------
+
+describe("liveFetch success", () => {
+	it("resolves to the message payload, not the envelope", async () => {
+		const { call } = await importFresh();
+		const payload = { server_time: "2026-08-10T00:00:00Z", ok: true };
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				fakeResponse({
+					status: 200,
+					// `other_envelope_field` stands in for things like `docs` that a
+					// 2xx body can carry alongside `message` — the caller must never
+					// see them.
+					jsonBody: { message: payload, other_envelope_field: "should-not-leak" },
+				}),
+			),
+		);
+
+		const result = await call({ method: METHOD, args: {}, intent: "read" });
+
+		expect(result).toEqual(payload);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 3. Structured 409 — the case this task exists for
+// ---------------------------------------------------------------------------
+
+describe("liveFetch structured error", () => {
+	it("carries error_code/details/status through a structured 409", async () => {
+		const { call } = await importFresh();
+		const body = {
+			exc_type: "OfflineSubmitError",
+			error_code: "siblings_not_ready",
+			details: { missing_offline_ids: ["a", "b"] },
+			http_status_code: 409,
+		};
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(fakeResponse({ status: 409, jsonBody: body })));
+
+		await expect(call({ method: METHOD, args: {}, intent: "read" })).rejects.toMatchObject({
+			error_code: "siblings_not_ready",
+			details: { missing_offline_ids: ["a", "b"] },
+			status: 409,
+			http_status_code: 409,
+			exc_type: "OfflineSubmitError",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 4. Non-JSON error body
+// ---------------------------------------------------------------------------
+
+describe("liveFetch non-JSON error body", () => {
+	it("does not throw a SyntaxError on an HTML 502 and leaves structured fields undefined", async () => {
+		const { call } = await importFresh();
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					fakeResponse({ status: 502, textBody: "<html>Bad Gateway</html>" }),
+				),
+		);
+
+		const err: unknown = await call({ method: METHOD, args: {}, intent: "read" }).catch(
+			(e: unknown) => e,
+		);
+
+		expect(err).toBeInstanceOf(Error);
+		expect(err).not.toBeInstanceOf(SyntaxError);
+		const e = err as Record<string, unknown>;
+		expect(e.status).toBe(502);
+		expect(e.error_code).toBeUndefined();
+		expect(e.details).toBeUndefined();
+		// http_status_code falls back to the real HTTP status when the
+		// (absent, unparseable) body has none of its own.
+		expect(e.http_status_code).toBe(502);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 5. Network rejection
+// ---------------------------------------------------------------------------
+
+describe("liveFetch network rejection", () => {
+	it("propagates a fetch rejection out of call() without reporting a success outcome", async () => {
+		const { call, connectivity } = await importFresh();
+		const reportSpy = vi.spyOn(connectivity, "reportRequestOutcome");
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+		await expect(call({ method: METHOD, args: {}, intent: "read" })).rejects.toThrow(
+			"Failed to fetch",
+		);
+
+		expect(reportSpy).not.toHaveBeenCalledWith("success");
+	});
+});

--- a/frontend/__tests__/utils/call-transport.test.ts
+++ b/frontend/__tests__/utils/call-transport.test.ts
@@ -11,7 +11,7 @@
  * explicitly overridden for this task only (see task-11-brief.md). `call.ts`
  * now performs its own `fetch()` instead of delegating to frappe-ui, and
  * there is no TypeScript compiler in this project to catch a shape mistake
- * in that rewrite — these five cases are the only real gate on it.
+ * in that rewrite — these six cases are the only real gate on it.
  *
  * Each test does its own `vi.resetModules()` + dynamic import (matching
  * `connectivity.test.ts`'s convention) so the connectivity module's
@@ -134,8 +134,9 @@ describe("liveFetch success", () => {
 // ---------------------------------------------------------------------------
 
 describe("liveFetch structured error", () => {
-	it("carries error_code/details/status through a structured 409", async () => {
-		const { call } = await importFresh();
+	it("carries error_code/details/status through a structured 409, and never reports success", async () => {
+		const { call, connectivity } = await importFresh();
+		const reportSpy = vi.spyOn(connectivity, "reportRequestOutcome");
 		const body = {
 			exc_type: "OfflineSubmitError",
 			error_code: "siblings_not_ready",
@@ -151,6 +152,11 @@ describe("liveFetch structured error", () => {
 			http_status_code: 409,
 			exc_type: "OfflineSubmitError",
 		});
+
+		// A 4xx/5xx must never be reported as a connectivity success — doing
+		// so would pin the detector "online" forever regardless of what the
+		// server is actually returning.
+		expect(reportSpy).not.toHaveBeenCalledWith("success");
 	});
 });
 
@@ -159,8 +165,9 @@ describe("liveFetch structured error", () => {
 // ---------------------------------------------------------------------------
 
 describe("liveFetch non-JSON error body", () => {
-	it("does not throw a SyntaxError on an HTML 502 and leaves structured fields undefined", async () => {
-		const { call } = await importFresh();
+	it("does not throw a SyntaxError on an HTML 502, leaves structured fields undefined, and never reports success", async () => {
+		const { call, connectivity } = await importFresh();
+		const reportSpy = vi.spyOn(connectivity, "reportRequestOutcome");
 		vi.stubGlobal(
 			"fetch",
 			vi
@@ -183,6 +190,10 @@ describe("liveFetch non-JSON error body", () => {
 		// http_status_code falls back to the real HTTP status when the
 		// (absent, unparseable) body has none of its own.
 		expect(e.http_status_code).toBe(502);
+
+		// Same rationale as the 409 case: a 5xx must never be reported as a
+		// connectivity success.
+		expect(reportSpy).not.toHaveBeenCalledWith("success");
 	});
 });
 
@@ -200,6 +211,36 @@ describe("liveFetch network rejection", () => {
 			"Failed to fetch",
 		);
 
+		expect(reportSpy).not.toHaveBeenCalledWith("success");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 6. Abort — a cancel is not a connectivity signal
+// ---------------------------------------------------------------------------
+
+describe("liveFetch abort", () => {
+	it("rejects with AbortError without classifying it as network_error", async () => {
+		const { call, connectivity } = await importFresh();
+		const reportSpy = vi.spyOn(connectivity, "reportRequestOutcome");
+		// This is what a real `fetch()` rejects with when its `signal` fires —
+		// simulated here since the stubbed fetch doesn't wire up AbortController
+		// itself.
+		const abortError = new DOMException("The operation was aborted.", "AbortError");
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			call({ method: METHOD, args: {}, intent: "read", abortSignal: controller.signal }),
+		).rejects.toMatchObject({ name: "AbortError" });
+
+		// The regression this guards: without a rethrow-before-classify, an
+		// abort falls through classifyFetchError's default and comes out as
+		// network_error, which pins the connectivity detector toward OFFLINE
+		// on a user-initiated cancel and — on a write — would enqueue the very
+		// request that was just cancelled.
+		expect(reportSpy).not.toHaveBeenCalledWith("network_error");
 		expect(reportSpy).not.toHaveBeenCalledWith("success");
 	});
 });

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -228,6 +228,7 @@
 <script>
 import { storeToRefs } from "pinia";
 import { call } from "@/utils/call";
+import { OPENING_DIALOG_CACHE_KEY } from "@/utils/call-registry";
 import hardwareUtils from "@/utils/hardwareUtils";
 import { useOutboxStore } from "@/stores/outbox";
 import { useConnectivityStore } from "@/stores/connectivity";
@@ -301,6 +302,18 @@ export default {
     },
     async logOut() {
       this.logged_out = true;
+      // The cached POS configuration must not outlive the session that fetched
+      // it; the next cashier may have a different profile set.
+      try {
+        // NOTE: getReadCache lives in "@/offline/runtime" (the registration
+        // shim), not "@/offline/read-cache" (the adapter implementations) —
+        // the latter never exports it. Corrected from the brief's snippet,
+        // which would have silently no-op'd here.
+        const { getReadCache } = await import("@/offline/runtime");
+        await getReadCache()?.invalidate(OPENING_DIALOG_CACHE_KEY);
+      } catch {
+        /* non-fatal */
+      }
       await call('logout');
       window.location.href = "/login";
     },

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -19,7 +19,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Expected amounts are provisional — this device is offline and cannot confirm totals with the server. Sales made earlier while online are not included.") }}
+					{{ __("Expected amounts are provisional — totals could not be confirmed with the server. Sales made earlier while online are not included.") }}
 				</v-alert>
 				<v-alert
 					v-if="dialog_data.pospire_uncertain_count"

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -12,6 +12,25 @@
 
 			<v-divider></v-divider>
 			<v-card-text class="px-6 py-4 overflow-y-auto" style="max-height:65vh;">
+				<v-alert
+					v-if="dialog_data.pospire_offline_stub"
+					type="warning"
+					variant="tonal"
+					density="compact"
+					class="mb-3"
+				>
+					{{ __("Expected amounts are provisional — this device is offline and cannot confirm totals with the server. Sales made earlier while online are not included.") }}
+				</v-alert>
+				<v-alert
+					v-if="dialog_data.pospire_uncertain_count"
+					type="info"
+					variant="tonal"
+					density="compact"
+					class="mb-3"
+				>
+					{{ __("Some queued invoices could not be confirmed with the server. Affected invoices:") }}
+					{{ dialog_data.pospire_uncertain_count }}
+				</v-alert>
 				<v-data-table
 					:headers="headers"
 					:items="dialog_data.payment_reconciliation"

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -2510,8 +2510,10 @@ export default {
 			// H4: shift is closing-pending — refuse Pay so a new invoice
 			// can't slip in under a closed shift. The cashier should open a
 			// new shift (or void the closing in reconciliation if they
-			// changed their mind). Durable check, not the in-session flag:
-			// after a reload no event has fired.
+			// changed their mind — reconcilePendingClosuresFromOutbox returns
+			// a voided shift to `open` and keeps its snapshot, so that really
+			// is a route back and not just a suggestion). Durable check, not
+			// the in-session flag: after a reload no event has fired.
 			if (await this.isShiftLocked()) {
 				toast.error(
 					__(

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -1183,6 +1183,11 @@ export default {
 			// show_payment so new sales don't slip into a shift whose
 			// strict-closure parent_offline_ids list was already snapshotted.
 			shiftClosingPending: false,
+			// Lifecycle UUID of the shift `shiftClosingPending` refers to.
+			// Without it a `shift_closing_complete` for shift A would clear a
+			// lock that shift B put up — chained offline shifts are supported,
+			// so the two can be in flight at the same time.
+			closingPendingShiftId: null,
 			discount_amount: 0,
 			additional_discount_percentage: 0,
 			total_tax: 0,
@@ -2505,8 +2510,9 @@ export default {
 			// H4: shift is closing-pending — refuse Pay so a new invoice
 			// can't slip in under a closed shift. The cashier should open a
 			// new shift (or void the closing in reconciliation if they
-			// changed their mind).
-			if (this.shiftClosingPending) {
+			// changed their mind). Durable check, not the in-session flag:
+			// after a reload no event has fired.
+			if (await this.isShiftLocked()) {
 				toast.error(
 					__(
 						"This shift is closing. Open a new shift before submitting another invoice.",
@@ -4225,6 +4231,29 @@ export default {
 				this.delivery_charges_rate = 0;
 			}
 		},
+		/**
+		 * Durable lock check.
+		 *
+		 * `shiftClosingPending` is only the in-session signal: after a reload
+		 * no `shift_closing_pending` event has fired in this session, and the
+		 * cart must not accept items on a shift whose close is already queued.
+		 * So fall through to the shift row, keyed on the ACTIVE shift's
+		 * lifecycle UUID — isSellingBlocked() returns true only when that shift
+		 * is itself closing, never because some other shift is.
+		 */
+		async isShiftLocked() {
+			if (this.shiftClosingPending) return true;
+			const activeId = this.pos_opening_shift?.pospire_lifecycle_id;
+			if (!activeId) return false;
+			try {
+				const { isSellingBlocked } = await import("@/offline/shift-lifecycle");
+				return await isSellingBlocked(activeId);
+			} catch {
+				// Fail open — never block a cashier from selling because of a
+				// storage error.
+				return false;
+			}
+		},
 	},
 
 	mounted() {
@@ -4238,7 +4267,9 @@ export default {
 				this.pos_profile = data.pos_profile;
 				this.customer = data.pos_profile.customer;
 				this.pos_opening_shift = data.pos_opening_shift;
-				this.shiftClosingPending = !!data.pos_opening_shift?.pospire_closing_pending;
+				// Closing-pending is NOT read off the snapshot any more — it
+				// lives on the durable shift row and is resolved lazily by
+				// isShiftLocked(), via this shift's `pospire_lifecycle_id`.
 				this.stock_settings = data.stock_settings;
 				this.float_precision = window.sys_defaults?.float_precision || 2;
 				this.currency_precision = window.sys_defaults?.currency_precision || 2;
@@ -4255,8 +4286,8 @@ export default {
 				this.update_delivery_charges();
 			}
 		});
-		this.eventBus.on("add_item", (item) => {
-			if (this.shiftClosingPending) {
+		this.eventBus.on("add_item", async (item) => {
+			if (await this.isShiftLocked()) {
 				toast.warning(
 					__(
 						"This shift is closing — its closing entry is queued. Open a new shift before ringing up another sale.",
@@ -4268,15 +4299,35 @@ export default {
 			this.add_item(item);
 		});
 
-		// H4: Pos.vue emits this when the offline closing is queued. The
-		// shift is locked locally — refuse new items and refuse Pay until
-		// either the closing syncs (Pos.vue's `shift_closing_complete`
-		// fires + redirects to OpeningDialog) or the cashier voids the
-		// closing in the reconciliation workspace.
-		this.eventBus.on("shift_closing_pending", () => {
+		// H4: Pos.vue emits this when the offline closing is queued (and
+		// again on reload, from the durable shift row). The lock applies only
+		// while the shift the cashier is actively on is itself closing — a
+		// closing-pending shift A must not lock selling on a freshly opened
+		// shift B, because chained offline shifts are supported and blocking
+		// them would halt sales during exactly the outage offline mode exists
+		// for. These three listeners are the fast in-session signal only;
+		// isShiftLocked() below is the durable answer.
+		this.eventBus.on("shift_closing_pending", (payload) => {
+			this.closingPendingShiftId = payload?.shift_lifecycle_id ?? null;
 			this.shiftClosingPending = true;
 		});
-		this.eventBus.on("shift_closing_complete", () => {
+		this.eventBus.on("shift_closing_complete", (payload) => {
+			if (
+				payload?.shift_lifecycle_id &&
+				this.closingPendingShiftId &&
+				payload.shift_lifecycle_id !== this.closingPendingShiftId
+			) {
+				return; // a different shift's closing resolved — stay locked
+			}
+			this.closingPendingShiftId = null;
+			this.shiftClosingPending = false;
+		});
+		this.eventBus.on("register_pos_data", () => {
+			// A new shift was just opened, so whatever was closing is no longer
+			// the shift the cashier is on. Clearing the in-session flag hands
+			// the decision back to isShiftLocked(), which reads the NEW shift's
+			// row and correctly allows selling on it.
+			this.closingPendingShiftId = null;
 			this.shiftClosingPending = false;
 		});
 		this.eventBus.on("update_customer", (customer) => {

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -4240,10 +4240,23 @@ export default {
 		 * So fall through to the shift row, keyed on the ACTIVE shift's
 		 * lifecycle UUID — isSellingBlocked() returns true only when that shift
 		 * is itself closing, never because some other shift is.
+		 *
+		 * The fast path must honour `closingPendingShiftId` for the same
+		 * reason. Relying on `register_pos_data` to clear the flag is not
+		 * enough: a shift change can arrive via `register_pos_profile` alone
+		 * (applyOpeningSnapshot(r) when the live response differs from the
+		 * cached snapshot), which would otherwise strand shift A's lock on
+		 * shift B. An unattributed lock (no id in the payload) still blocks —
+		 * we can't prove it belongs to another shift.
 		 */
 		async isShiftLocked() {
-			if (this.shiftClosingPending) return true;
 			const activeId = this.pos_opening_shift?.pospire_lifecycle_id;
+			if (
+				this.shiftClosingPending &&
+				(!this.closingPendingShiftId || this.closingPendingShiftId === activeId)
+			) {
+				return true;
+			}
 			if (!activeId) return false;
 			try {
 				const { isSellingBlocked } = await import("@/offline/shift-lifecycle");

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -117,6 +117,23 @@
 				</v-container>
 			</v-card-text>
 
+			<v-alert
+				v-if="config_unavailable"
+				type="warning"
+				variant="tonal"
+				class="mx-6 mb-2"
+			>
+				{{ __("POS configuration is not available on this device yet. Connect to the network once to load it, then reopen this dialog.") }}
+			</v-alert>
+			<v-alert
+				v-else-if="config_is_stale"
+				type="info"
+				variant="tonal"
+				density="compact"
+				class="mx-6 mb-2"
+			>
+				{{ __("Showing saved POS configuration. It will refresh when the connection returns.") }}
+			</v-alert>
 			<v-divider />
 			<v-card-actions class="px-6 py-4 enhanced-modal-header">
 				<v-spacer />
@@ -126,7 +143,7 @@
 				<v-btn
 					variant="elevated"
 					color="primary"
-					:disabled="is_loading"
+					:disabled="is_loading || config_unavailable"
 					@click="submit_dialog"
 				>
 					{{ __("Submit") }}
@@ -137,7 +154,8 @@
 </template>
 
 <script>
-import { call } from "@/utils/call";
+import { call, isStaleReadResult, unwrapStale } from "@/utils/call";
+import { OPENING_DIALOG_CACHE_KEY } from "@/utils/call-registry";
 import connectivity from "@/offline/connectivity";
 import format from "@/utils/format";
 import { toast } from "vue3-toastify";
@@ -177,9 +195,11 @@ export default {
 			snack: false, // TODO : need to remove
 			snackColor: "", // TODO : need to remove
 			snackText: "", // TODO : need to remove
-			denomination_config: {},       
-			denomination_rows: [],         
-			denominations_enabled: false,    
+			denomination_config: {},
+			denomination_rows: [],
+			denominations_enabled: false,
+			config_is_stale: false,
+			config_unavailable: false,
 		};
 	},
 	watch: {
@@ -260,100 +280,80 @@ export default {
 			this.eventBus.emit("close_opening_dialog");
 		},
 		async get_opening_dialog_data() {
-			// `get_opening_dialog_data` is registered as offline:false, so a
-			// cold-start with no connectivity throws here and the dialog
-			// stays empty (companies/pos_profiles/payments_methods all
-			// blank). submit_dialog then immediately bails on the empty
-			// payments check, leaving the cashier stuck.
-			//
-			// Two-level offline fallback:
-			//   1. Cache the live response under `pospire.opening_dialog_data_cache`
-			//      on success. Reuse it directly when the live call fails.
-			//   2. If even the cache is missing, synthesise a minimal payload
-			//      from the broader `pospire.opening_shift_snapshot` (which
-			//      Pos.vue caches from the last `check_opening_shift`). It
-			//      contains the full POS Profile doc — enough to derive the
-			//      single-company / single-profile / payments shape.
-			const DIALOG_CACHE_KEY = "pospire.opening_dialog_data_cache";
-			const SHIFT_SNAPSHOT_KEY = "pospire.opening_shift_snapshot";
+			// Durable read-cache. The registry marks this method offline:true
+			// and OPENING_DIALOG_CACHE_KEY is allowlisted in DURABLE_KEYS, so a
+			// successful online call persists to Dexie and is served after a
+			// reload while offline. Pos.vue warms it on every online boot,
+			// because a terminal that runs all day on an already-open shift
+			// never opens this dialog and would otherwise arrive here cold.
 			const vm = this;
 			let r = null;
 			try {
-				r = await call("pospire.pospire.api.posapp.get_opening_dialog_data", {});
-				if (r) {
-					try {
-						localStorage.setItem(DIALOG_CACHE_KEY, JSON.stringify(r));
-					} catch {
-						/* quota / privacy mode — non-fatal */
-					}
-				}
-			} catch (err) {
-				console.warn(
-					"[OpeningDialog] get_opening_dialog_data failed; trying offline fallbacks",
-					err,
-				);
-				try {
-					const cached = localStorage.getItem(DIALOG_CACHE_KEY);
-					if (cached) r = JSON.parse(cached);
-				} catch {
-					/* corrupt cache */
-				}
-				if (!r) {
-					r = this.synthesizeDialogDataFromShiftSnapshot(SHIFT_SNAPSHOT_KEY);
-				}
-			}
-
-			if (r) {
-				(r.companies || []).forEach((element) => {
-					vm.companies.push(element.name);
+				const raw = await call({
+					method: "pospire.pospire.api.posapp.get_opening_dialog_data",
+					args: {},
+					intent: "read",
+					cacheKey: OPENING_DIALOG_CACHE_KEY,
 				});
-				vm.company = vm.companies[0];
-				vm.pos_profiles_data = r.pos_profiles_data || [];
-				vm.payments_method_data = r.payments_method || [];
-				vm.denomination_config = r.denomination_config || {};
+				// Capture staleness BEFORE unwrapping — unwrapStale discards it.
+				this.config_is_stale = isStaleReadResult(raw);
+				r = unwrapStale(raw);
+			} catch (err) {
+				console.warn("[OpeningDialog] get_opening_dialog_data unavailable", err);
+				this.config_unavailable = true;
+				return;
 			}
-		},
 
-		/**
-		 * Build a minimal `get_opening_dialog_data` shape from the cached
-		 * opening-shift snapshot. The shape mirrors what the live endpoint
-		 * returns so the watchers in this component (which key off
-		 * `pos_profiles_data` company match and `payments_method_data` parent
-		 * match) can do their thing without code changes.
-		 *
-		 * Only used when both the live call AND the dialog cache are missing —
-		 * i.e. the device booted cold offline. The snapshot's pos_profile
-		 * carries the full payments[] child table with mode_of_payment +
-		 * default flag, which is enough to populate the dialog's payment-
-		 * method rows.
-		 */
-		synthesizeDialogDataFromShiftSnapshot(snapshotKey) {
-			try {
-				const raw = localStorage.getItem(snapshotKey);
-				if (!raw) return null;
-				const snap = JSON.parse(raw);
-				if (!snap?.pos_profile) return null;
-				const profile = snap.pos_profile;
-				const companyName = profile.company || snap.company?.name;
-				if (!companyName) return null;
-				return {
-					companies: [{ name: companyName }],
-					pos_profiles_data: [{ name: profile.name, company: companyName }],
-					payments_method: (profile.payments || []).map((p) => ({
-						parent: profile.name,
-						mode_of_payment: p.mode_of_payment,
-						currency: profile.currency,
-						default: p.default,
-					})),
-					// Denomination config isn't on the shift snapshot — leaving
-					// it empty disables the denomination grid offline. The
-					// cashier enters straight cash amounts; reconciliation at
-					// online sync verifies totals.
-					denomination_config: {},
-				};
-			} catch {
-				return null;
+			if (!r) {
+				this.config_unavailable = true;
+				return;
 			}
+
+			this.config_unavailable = false;
+			(r.companies || []).forEach((element) => {
+				vm.companies.push(element.name);
+			});
+			vm.company = vm.companies[0];
+			vm.pos_profiles_data = r.pos_profiles_data || [];
+			vm.payments_method_data = r.payments_method || [];
+			vm.denomination_config = r.denomination_config || {};
+		},
+		async refresh_dialog_config() {
+			let fresh = null;
+			try {
+				const raw = await call({
+					method: "pospire.pospire.api.posapp.get_opening_dialog_data",
+					args: {},
+					intent: "read",
+					cacheKey: OPENING_DIALOG_CACHE_KEY,
+				});
+				this.config_is_stale = isStaleReadResult(raw);
+				fresh = unwrapStale(raw);
+			} catch {
+				return; // still unreachable — keep what we have
+			}
+			if (!fresh) return;
+
+			this.config_unavailable = false;
+			this.payments_method_data = fresh.payments_method || [];
+			this.denomination_config = fresh.denomination_config || {};
+
+			// Re-derive the grid for the selected profile WITHOUT resetting
+			// quantities the cashier has already counted into it.
+			const config = this.denomination_config[this.pos_profile];
+			if (!config?.enabled) return;
+			const typed = new Map(
+				this.denomination_rows.map((row) => [row.denomination, row.quantity]),
+			);
+			this.denominations_enabled = true;
+			this.denomination_rows = (config.denominations || []).map((d) => ({
+				denomination: d.denomination,
+				denomination_name: d.denomination_name,
+				denomination_value: d.denomination_value,
+				currency: d.currency,
+				quantity: typed.get(d.denomination) ?? 0,
+				amount: 0,
+			}));
 		},
 		async submit_dialog() {
 			if (!this.payments_methods.length || !this.company || !this.pos_profile) {
@@ -552,6 +552,20 @@ export default {
 		this.$nextTick(function () {
 			this.get_opening_dialog_data();
 		});
+	},
+	mounted() {
+		// isOnline() needs THRESHOLD_ONLINE = 3 consecutive successful pings
+		// before it flips back, and any offline:false read throws without
+		// touching the network during that window. A dialog opened in the
+		// gap would otherwise stay on stale config for its whole lifetime.
+		this._unsubConnectivity = connectivity.onChange(() => {
+			if (!connectivity.isOnline()) return;
+			if (!this.config_is_stale && !this.config_unavailable) return;
+			this.refresh_dialog_config();
+		});
+	},
+	beforeUnmount() {
+		if (this._unsubConnectivity) this._unsubConnectivity();
 	},
 };
 </script>

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -200,6 +200,7 @@ export default {
 			denominations_enabled: false,
 			config_is_stale: false,
 			config_unavailable: false,
+			unsubConnectivity: null,
 		};
 	},
 	watch: {
@@ -279,6 +280,28 @@ export default {
 		close_opening_dialog() {
 			this.eventBus.emit("close_opening_dialog");
 		},
+		/**
+		 * Single source of truth for populating the dialog from a
+		 * `get_opening_dialog_data` payload. Used by BOTH the initial fetch
+		 * and the reconnect refresh — a previous version only had
+		 * `refresh_dialog_config` update `payments_method_data` /
+		 * `denomination_config`, which never repopulated `companies` /
+		 * `pos_profiles_data`. Since `company`/`pos_profile` stayed "" on a
+		 * cold-boot-offline dialog, reassigning `payments_method_data` alone
+		 * never re-fired the `pos_profile` watcher, so Submit flipped
+		 * enabled on reconnect while the form was still completely blank —
+		 * the exact silent dead end this task exists to remove.
+		 *
+		 * Assigns `companies` (does NOT push) so re-running this on refresh
+		 * doesn't duplicate entries.
+		 */
+		applyDialogData(r) {
+			this.companies = (r.companies || []).map((element) => element.name);
+			this.company = this.companies[0];
+			this.pos_profiles_data = r.pos_profiles_data || [];
+			this.payments_method_data = r.payments_method || [];
+			this.denomination_config = r.denomination_config || {};
+		},
 		async get_opening_dialog_data() {
 			// Durable read-cache. The registry marks this method offline:true
 			// and OPENING_DIALOG_CACHE_KEY is allowlisted in DURABLE_KEYS, so a
@@ -286,7 +309,6 @@ export default {
 			// reload while offline. Pos.vue warms it on every online boot,
 			// because a terminal that runs all day on an already-open shift
 			// never opens this dialog and would otherwise arrive here cold.
-			const vm = this;
 			let r = null;
 			try {
 				const raw = await call({
@@ -310,13 +332,7 @@ export default {
 			}
 
 			this.config_unavailable = false;
-			(r.companies || []).forEach((element) => {
-				vm.companies.push(element.name);
-			});
-			vm.company = vm.companies[0];
-			vm.pos_profiles_data = r.pos_profiles_data || [];
-			vm.payments_method_data = r.payments_method || [];
-			vm.denomination_config = r.denomination_config || {};
+			this.applyDialogData(r);
 		},
 		async refresh_dialog_config() {
 			let fresh = null;
@@ -335,18 +351,44 @@ export default {
 			if (!fresh) return;
 
 			this.config_unavailable = false;
-			this.payments_method_data = fresh.payments_method || [];
-			this.denomination_config = fresh.denomination_config || {};
+			// `previousProfile` lets us tell whether `applyDialogData` just
+			// drove the `company` → `pos_profile` watcher chain from a blank
+			// selection (cold-boot-offline reconnect): in that case the
+			// `pos_profile` watcher below already built payments_methods AND
+			// denomination_rows from scratch, so re-deriving them again here
+			// would both duplicate work and double the misconfiguration
+			// toast. When the profile selection is UNCHANGED, neither
+			// watcher fires (Vue only calls a watcher when the value
+			// actually changes), so payments_methods/denomination_rows are
+			// left exactly as the cashier last saw them — which is what
+			// preserves typed quantities across a reconnect.
+			const previousProfile = this.pos_profile;
+			this.applyDialogData(fresh);
+			if (this.pos_profile !== previousProfile) return;
 
 			// Re-derive the grid for the selected profile WITHOUT resetting
-			// quantities the cashier has already counted into it.
+			// quantities the cashier has already counted into it. Mirrors
+			// the `pos_profile` watcher's gate EXACTLY: `enabled: true` alone
+			// does not mean render the grid — {enabled:true, denominations:[]}
+			// is a real "misconfigured" state. Locking the cash field on an
+			// unconfigured-but-enabled profile (by gating on `enabled` alone)
+			// would strand the cashier with no way to enter opening cash.
 			const config = this.denomination_config[this.pos_profile];
-			if (!config?.enabled) return;
+			if (!config?.denominations?.length) {
+				this.denominations_enabled = false;
+				this.denomination_rows = [];
+				if (config) {
+					toast.warning(__("Cash denominations are enabled for this profile but no denomination rows are configured."), {
+						autoClose: 5000,
+					});
+				}
+				return;
+			}
 			const typed = new Map(
 				this.denomination_rows.map((row) => [row.denomination, row.quantity]),
 			);
 			this.denominations_enabled = true;
-			this.denomination_rows = (config.denominations || []).map((d) => ({
+			this.denomination_rows = config.denominations.map((d) => ({
 				denomination: d.denomination,
 				denomination_name: d.denomination_name,
 				denomination_value: d.denomination_value,
@@ -558,14 +600,14 @@ export default {
 		// before it flips back, and any offline:false read throws without
 		// touching the network during that window. A dialog opened in the
 		// gap would otherwise stay on stale config for its whole lifetime.
-		this._unsubConnectivity = connectivity.onChange(() => {
+		this.unsubConnectivity = connectivity.onChange(() => {
 			if (!connectivity.isOnline()) return;
 			if (!this.config_is_stale && !this.config_unavailable) return;
 			this.refresh_dialog_config();
 		});
 	},
 	beforeUnmount() {
-		if (this._unsubConnectivity) this._unsubConnectivity();
+		if (this.unsubConnectivity) this.unsubConnectivity();
 	},
 };
 </script>

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -135,7 +135,7 @@
 				variant="tonal"
 				class="mx-6 mb-2"
 			>
-				{{ __("POS configuration is not available on this device yet. Connect to the network once to load it, then reopen this dialog.") }}
+				{{ __("POS configuration could not be loaded on this device. If you are offline, connect once to load it; if you are online, the server refused the request — check that your account has POS access, then reopen this dialog.") }}
 			</v-alert>
 			<v-alert
 				v-else-if="config_is_stale"
@@ -224,6 +224,17 @@ export default {
 			config_is_stale: false,
 			config_unavailable: false,
 			unsubConnectivity: null,
+			/**
+			 * Inputs to `submit_can_never_succeed` that live outside Vue's
+			 * reactivity (a connectivity module, localStorage). Refreshed by
+			 * `refresh_submit_gate()` on create and on every connectivity
+			 * change — the only two moments either can change while this
+			 * dialog is on screen. The outbox store is reactive on its own,
+			 * so it is read directly in the computed instead.
+			 */
+			is_online: true,
+			snapshot_usable: true,
+			outbox_store: null,
 		};
 	},
 	watch: {
@@ -311,15 +322,50 @@ export default {
 
 			/**
 			 * Submit is bound to `:disabled="is_loading || config_unavailable"`,
-			 * but `submit_dialog` ALSO returns silently on this condition — so
-			 * the button can be enabled yet inert. Mirrored here (not merged
-			 * into the binding) so the two stay visibly paired: if that guard
-			 * ever changes, this is the line to change with it.
+			 * but `submit_dialog` has its OWN refuse-conditions that leave the
+			 * button enabled and simply return — so the button can be enabled
+			 * yet guaranteed to get the cashier nowhere. Every such condition
+			 * has to be mirrored here, because `can_exit_dialog` below is what
+			 * stops that turning into a locked-in dialog.
+			 *
+			 * Named for the property that matters (`can never succeed`), not
+			 * for how it fails: two of the three are toast-and-return, not
+			 * silent no-ops, but a toast the cashier can do nothing about is
+			 * not a way forward.
+			 *
+			 * The three, in `submit_dialog`'s own order:
+			 *   1. no usable form (no payment rows / no company / no profile)
+			 *      — the original `submit_is_inert`;
+			 *   2. offline with the chained-shift cap reached (>= 3 unsynced
+			 *      openings). Reachable by a supported flow: open offline,
+			 *      close offline, three times over. Only reconnecting clears
+			 *      it, which is precisely what a trapped cashier cannot do
+			 *      from inside a `persistent` dialog;
+			 *   3. offline with no usable opening snapshot — same shape,
+			 *      narrower trigger.
+			 * Conditions 2 and 3 are gated on `is_online` because
+			 * `submit_dialog` only evaluates them on the offline branch.
+			 *
+			 * NOT mirrored: the two validation toasts (negative denomination
+			 * quantity, invalid amount). Those describe input the cashier can
+			 * correct in this dialog, so Submit CAN succeed after a fix — they
+			 * are feedback, not a dead end.
+			 *
+			 * The `?? 0` on the outbox count mirrors `submit_dialog`'s own
+			 * fail-open behaviour when the store is unavailable: if the gate
+			 * would not fire, this must not claim it would.
 			 */
-			submit_is_inert() {
-				return (
-					!this.payments_methods.length || !this.company || !this.pos_profile
-				);
+			submit_can_never_succeed() {
+				if (
+					!this.payments_methods.length ||
+					!this.company ||
+					!this.pos_profile
+				) {
+					return true;
+				}
+				if (this.is_online) return false;
+				if ((this.outbox_store?.unsyncedOpeningCount ?? 0) >= 3) return true;
+				return !this.snapshot_usable;
 			},
 
 			/**
@@ -330,9 +376,10 @@ export default {
 			 * cashier out of here — whether because it is disabled
 			 * (`config_unavailable`, i.e. offline with a cold config cache,
 			 * precisely the case that follows an offline close) or because it
-			 * is enabled but would no-op (`submit_is_inert`, config fetched but
-			 * carrying no usable profile). Either way the cashier keeps a way
-			 * forward or a way out, always.
+			 * is enabled but guaranteed to refuse (`submit_can_never_succeed`
+			 * — no usable profile, the chained-shift cap, or no opening
+			 * snapshot). Either way the cashier keeps a way forward or a way
+			 * out, always.
 			 *
 			 * `is_loading` deliberately does NOT lift the gate: it is transient,
 			 * self-clearing in submit_dialog's `finally`, and entered only by
@@ -341,7 +388,9 @@ export default {
 			 */
 			can_exit_dialog() {
 				return (
-					!this.closingPending || this.config_unavailable || this.submit_is_inert
+					!this.closingPending ||
+					this.config_unavailable ||
+					this.submit_can_never_succeed
 				);
 			},
 
@@ -349,6 +398,56 @@ export default {
 	methods: {
 		close_opening_dialog() {
 			this.eventBus.emit("close_opening_dialog");
+		},
+		/** The opening snapshot Pos.vue persists, or null. Never throws. */
+		read_opening_snapshot() {
+			try {
+				const raw = localStorage.getItem("pospire.opening_shift_snapshot");
+				return raw ? JSON.parse(raw) : null;
+			} catch {
+				return null;
+			}
+		},
+		/**
+		 * Is the cached opening snapshot rich enough to synthesise the
+		 * `register_pos_data` payload from after an offline enqueue?
+		 *
+		 * ONE predicate, used by three call sites that used to disagree: the
+		 * pre-call offline guard checked only `pos_profile && company` while
+		 * the post-ack handler additionally required `pos_profile.name` and a
+		 * resolvable company name. A snapshot in between (say `pos_profile:
+		 * {}`) passed the guard, queued an opening entry, and only THEN
+		 * failed — leaving an orphan opening in the outbox on every attempt.
+		 * Now the strict form gates both, so nothing is queued that cannot be
+		 * registered, and `submit_can_never_succeed` can mirror the guard
+		 * exactly instead of approximately.
+		 *
+		 * The post-ack check still stands as well: on the online path the
+		 * pre-call guard is skipped entirely, and `call()` can still decide to
+		 * enqueue mid-flight (forceQueue, or a blip after the probe).
+		 */
+		snapshot_is_usable(snapshot) {
+			return !!(
+				snapshot &&
+				snapshot.pos_profile &&
+				typeof snapshot.pos_profile === "object" &&
+				snapshot.pos_profile.name &&
+				snapshot.company &&
+				(typeof snapshot.company === "object"
+					? snapshot.company.name
+					: snapshot.company)
+			);
+		},
+		/**
+		 * Re-read the two non-reactive inputs to `submit_can_never_succeed`.
+		 * Connectivity lives in a plain module and the snapshot in
+		 * localStorage, so neither notifies Vue on its own.
+		 */
+		refresh_submit_gate() {
+			this.is_online = connectivity.isOnline();
+			this.snapshot_usable = this.snapshot_is_usable(
+				this.read_opening_snapshot(),
+			);
 		},
 		/**
 		 * Single source of truth for populating the dialog from a
@@ -403,8 +502,23 @@ export default {
 				this.pos_profiles = this.pos_profiles_data
 					.filter((p) => p.company === this.company)
 					.map((p) => p.name);
+				const previous = this.pos_profile;
 				if (!this.pos_profile || !this.pos_profiles.includes(this.pos_profile)) {
 					this.pos_profile = this.pos_profiles[0] || "";
+				}
+				// The re-selection above changes the denomination grid out from
+				// under the cashier — possibly mid-count, possibly removing it
+				// entirely. `refresh_dialog_config` bails as soon as the profile
+				// changed (the watcher chain has already rebuilt everything), so
+				// this is the only place that can say why. Without it the grid
+				// just vanishes with no explanation at all.
+				if (previous && this.pos_profile !== previous) {
+					toast.warning(
+						this.pos_profile
+							? __("The POS Profile you had selected is no longer available. A different profile has been selected — re-check the opening amounts before submitting.")
+							: __("The POS Profile you had selected is no longer available and this company has no other profile. Contact your manager before opening a shift."),
+						{ autoClose: 8000 },
+					);
 				}
 			}
 
@@ -593,13 +707,7 @@ export default {
 			// snapshot was only read in the `offline` branch, the
 			// offline-ack handler downstream would dereference a null
 			// snapshot when running through an "online but enqueued" path.
-			let snapshot = null;
-			try {
-				const raw = localStorage.getItem("pospire.opening_shift_snapshot");
-				if (raw) snapshot = JSON.parse(raw);
-			} catch {
-				snapshot = null;
-			}
+			const snapshot = this.read_opening_snapshot();
 
 			const offline = !connectivity.isOnline();
 			if (offline) {
@@ -626,7 +734,7 @@ export default {
 					console.warn("[OpeningDialog] chained-shifts gate skipped", err);
 				}
 
-				if (!snapshot || !snapshot.pos_profile || !snapshot.company) {
+				if (!this.snapshot_is_usable(snapshot)) {
 					this.is_loading = false;
 					toast.warning(
 						__("Opening a shift offline needs a recent online session on this device. Reconnect and open one shift online first."),
@@ -660,16 +768,7 @@ export default {
 					// components expect (pos_profile.payments, company doc
 					// fields). Surface a clear error instead of crashing on
 					// `snapshot.pos_profile.name`.
-					const okSnapshot =
-						snapshot &&
-						snapshot.pos_profile &&
-						typeof snapshot.pos_profile === "object" &&
-						snapshot.pos_profile.name &&
-						snapshot.company &&
-						(typeof snapshot.company === "object"
-							? snapshot.company.name
-							: snapshot.company);
-					if (!okSnapshot) {
+					if (!this.snapshot_is_usable(snapshot)) {
 						this.is_loading = false;
 						toast.error(
 							__("Shift queued offline but the cached profile is missing. Reload while online to refresh the snapshot before opening another shift."),
@@ -712,6 +811,19 @@ export default {
 					this.eventBus.emit("set_company", r.company);
 					this.close_opening_dialog();
 				}
+			} catch (err) {
+				// A live rejection (permission error, validation failure, 500)
+				// used to have no handler at all: `finally` reset the spinner
+				// and the rejection escaped as an unhandled promise rejection,
+				// so the cashier saw the button un-press and nothing else. That
+				// is bad on its own; with the exits hidden during a queued
+				// close it is silent AND exit-less.
+				console.error("[OpeningDialog] create_opening_voucher failed", err);
+				toast.error(
+					(err && err.message) ||
+						__("Could not open the shift. Please try again."),
+					{ autoClose: 7000 },
+				);
 			} finally {
 				this.is_loading = false;
 			}
@@ -721,16 +833,36 @@ export default {
 		},
 	},
 	created: function () {
+		// Before the first paint: `can_exit_dialog` reads this, and defaulting
+		// to "online, snapshot fine" for a tick would flash the exits away on
+		// a dialog that is genuinely exit-worthy.
+		this.refresh_submit_gate();
 		this.$nextTick(function () {
 			this.get_opening_dialog_data();
 		});
 	},
 	mounted() {
+		// Dynamic, and tolerant of failure, for the same reason submit_dialog's
+		// own chained-shifts gate is: the store may not be initialised yet.
+		// `submit_can_never_succeed` fails open on a null store, matching what
+		// submit_dialog itself does when the import fails.
+		import("@/stores/outbox")
+			.then(({ useOutboxStore }) => {
+				this.outbox_store = useOutboxStore();
+			})
+			.catch((err) => {
+				console.warn("[OpeningDialog] outbox store unavailable", err);
+			});
 		// isOnline() needs THRESHOLD_ONLINE = 3 consecutive successful pings
 		// before it flips back, and any offline:false read throws without
 		// touching the network during that window. A dialog opened in the
 		// gap would otherwise stay on stale config for its whole lifetime.
 		this.unsubConnectivity = connectivity.onChange(() => {
+			// Unconditional, and before the early returns below: connectivity
+			// is one of the two inputs to the never-trap gate, and going
+			// offline (which takes neither branch below) is exactly when the
+			// exits need to come back.
+			this.refresh_submit_gate();
 			if (!connectivity.isOnline()) return;
 			if (!this.config_is_stale && !this.config_unavailable) return;
 			this.refresh_dialog_config();

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -57,7 +57,7 @@
 										:prefix="currencySymbol(pos_profile.currency)"
 										:readonly="
 											denominations_enabled ||
-											props.item.mode_of_payment !== (denomination_config[pos_profile]?.cash_mode || 'Cash')
+											props.item.mode_of_payment !== cashModeForSelectedProfile
 										"
 										/>
 								</template>
@@ -273,7 +273,18 @@ export default {
 		return this.denomination_rows.reduce((sum, row) => {
 			return sum + (row.denomination_value * (row.quantity || 0));
 		}, 0);
-	}
+	},
+
+			/**
+			 * Cash MOP for the selected profile, straight from the server
+			 * policy. Never falls back to a snapshot — Task 6 deletes the
+			 * snapshot dependency, and reintroducing it here would restore the
+			 * second source of truth by the back door. The literal "Cash" is a
+			 * last resort only for profiles that send no policy at all.
+			 */
+			cashModeForSelectedProfile() {
+				return this.denomination_config[this.pos_profile]?.cash_mode || "Cash";
+			},
 
 	},
 	methods: {

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -310,13 +310,29 @@ export default {
 			},
 
 			/**
-			 * INVARIANT: this dialog must never present zero enabled controls.
-			 * It is `persistent`, so there is no click-away or Esc; both exits
-			 * (header X, Cancel) call the same `go_desk()`, and Submit is
-			 * disabled whenever `config_unavailable` — which is precisely the
-			 * offline-with-a-cold-cache case that follows an offline close. So
-			 * the closing-pending gate is lifted the moment Submit is
-			 * unusable: the cashier keeps a way forward, or a way out, always.
+			 * Submit is bound to `:disabled="is_loading || config_unavailable"`,
+			 * but `submit_dialog` ALSO returns silently on this condition — so
+			 * the button can be enabled yet inert. Mirrored here (not merged
+			 * into the binding) so the two stay visibly paired: if that guard
+			 * ever changes, this is the line to change with it.
+			 */
+			submit_is_inert() {
+				return (
+					!this.payments_methods.length || !this.company || !this.pos_profile
+				);
+			},
+
+			/**
+			 * INVARIANT: this dialog must never present zero USABLE controls.
+			 * It is `persistent`, so there is no click-away or Esc, and both
+			 * exits (header X, Cancel) call the same `go_desk()`. So the
+			 * closing-pending gate is lifted the moment Submit cannot get the
+			 * cashier out of here — whether because it is disabled
+			 * (`config_unavailable`, i.e. offline with a cold config cache,
+			 * precisely the case that follows an offline close) or because it
+			 * is enabled but would no-op (`submit_is_inert`, config fetched but
+			 * carrying no usable profile). Either way the cashier keeps a way
+			 * forward or a way out, always.
 			 *
 			 * `is_loading` deliberately does NOT lift the gate: it is transient,
 			 * self-clearing in submit_dialog's `finally`, and entered only by
@@ -324,7 +340,9 @@ export default {
 			 * on every submit would be worse.
 			 */
 			can_exit_dialog() {
-				return !this.closingPending || this.config_unavailable;
+				return (
+					!this.closingPending || this.config_unavailable || this.submit_is_inert
+				);
 			},
 
 	},

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -294,13 +294,59 @@ export default {
 		 *
 		 * Assigns `companies` (does NOT push) so re-running this on refresh
 		 * doesn't duplicate entries.
+		 *
+		 * Selection is STICKY: an already-valid `company`/`pos_profile` is
+		 * kept rather than forced back to index 0. In a multi-company setup
+		 * where the cashier's company isn't first in the list, unconditionally
+		 * reassigning `companies[0]` on a steady-state reconnect fired the
+		 * `company` -> `pos_profile` watcher chain, which rebuilds
+		 * `denomination_rows` with `quantity: 0` — silently wiping an
+		 * in-progress cash count out from under the cashier mid-count. Only
+		 * fall back to the first entry when the current pick no longer
+		 * resolves (cold start, or the pick vanished from the refreshed list).
 		 */
 		applyDialogData(r) {
 			this.companies = (r.companies || []).map((element) => element.name);
-			this.company = this.companies[0];
+			const companySticky = Boolean(this.company) && this.companies.includes(this.company);
+			if (!companySticky) {
+				this.company = this.companies[0];
+			}
+
 			this.pos_profiles_data = r.pos_profiles_data || [];
 			this.payments_method_data = r.payments_method || [];
 			this.denomination_config = r.denomination_config || {};
+
+			// The `company` watcher below only re-derives `pos_profiles` /
+			// `pos_profile` when `company` itself CHANGES value, so it does
+			// NOT fire on a sticky company. If `pos_profiles_data` changed
+			// under a sticky company (e.g. an admin disabled the cashier's
+			// selected profile while this device was offline), a stale
+			// `pos_profile` would be left pointing at nothing —
+			// `denomination_config[this.pos_profile]` resolves to `undefined`
+			// and the grid silently disappears with no toast. Re-validate
+			// explicitly here, mirroring the watcher's own fallback (keep the
+			// current pick if it's still valid, else take `pos_profiles[0]`).
+			// Only needed for the sticky-company branch: when company DID
+			// change, the watcher already covers this correctly on its own —
+			// adding this unconditionally would just duplicate that work.
+			if (companySticky) {
+				this.pos_profiles = this.pos_profiles_data
+					.filter((p) => p.company === this.company)
+					.map((p) => p.name);
+				if (!this.pos_profile || !this.pos_profiles.includes(this.pos_profile)) {
+					this.pos_profile = this.pos_profiles[0] || "";
+				}
+			}
+
+			// Tell the caller whether `pos_profile` was (re)validated
+			// SYNCHRONOUSLY above, as opposed to being left for the `company`
+			// watcher to resolve on Vue's next microtask flush. Callers that
+			// need to know the FINAL `pos_profile` right after calling this
+			// method (see `refresh_dialog_config`) can only trust a
+			// before/after comparison when `companySticky` is true — a
+			// non-sticky company change hasn't actually updated `pos_profile`
+			// yet at this point, it's merely been scheduled to.
+			return { companySticky };
 		},
 		async get_opening_dialog_data() {
 			// Durable read-cache. The registry marks this method offline:true
@@ -351,19 +397,33 @@ export default {
 			if (!fresh) return;
 
 			this.config_unavailable = false;
-			// `previousProfile` lets us tell whether `applyDialogData` just
-			// drove the `company` → `pos_profile` watcher chain from a blank
-			// selection (cold-boot-offline reconnect): in that case the
-			// `pos_profile` watcher below already built payments_methods AND
-			// denomination_rows from scratch, so re-deriving them again here
-			// would both duplicate work and double the misconfiguration
-			// toast. When the profile selection is UNCHANGED, neither
-			// watcher fires (Vue only calls a watcher when the value
-			// actually changes), so payments_methods/denomination_rows are
-			// left exactly as the cashier last saw them — which is what
-			// preserves typed quantities across a reconnect.
+			// `previousProfile` lets us tell whether the profile selection
+			// actually changed vs. staying exactly as the cashier left it —
+			// only in the latter case do neither the `company` nor
+			// `pos_profile` watcher fire (Vue only calls a watcher when the
+			// value actually changes), leaving payments_methods /
+			// denomination_rows untouched, which is what preserves typed
+			// quantities across a reconnect. When the profile DID change,
+			// the watcher chain already rebuilt everything from scratch (a
+			// cold start has nothing to preserve; a vanished profile has
+			// nothing valid left to preserve), so re-deriving it again below
+			// would just duplicate that work and double any toast.
+			//
+			// This before/after comparison is only trustworthy when
+			// `companySticky` is true. `applyDialogData` settles
+			// `pos_profile` SYNCHRONOUSLY in that branch (see its comment),
+			// so reading `this.pos_profile` immediately afterward reflects
+			// the real outcome. When the company was NOT sticky,
+			// `pos_profile` is left for the async `company` watcher to
+			// resolve on Vue's next microtask flush (`flush: 'pre'`, the
+			// default) — reading it synchronously here would still show the
+			// OLD value, making the comparison a false negative. Bail out
+			// via `companySticky` instead of trying to read a value that
+			// hasn't been written yet. (If any watcher on this component is
+			// ever declared `flush: 'sync'`, re-check this reasoning.)
 			const previousProfile = this.pos_profile;
-			this.applyDialogData(fresh);
+			const { companySticky } = this.applyDialogData(fresh);
+			if (!companySticky) return;
 			if (this.pos_profile !== previousProfile) return;
 
 			// Re-derive the grid for the selected profile WITHOUT resetting

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -8,13 +8,14 @@
 					{{ __("Create POS Opening Shift") }}
 				</span>
 				<!--
-					Hidden only while a close is queued: go_desk() navigates to
-					/app and tears down the SPA, which on that path would strand
-					the cashier with a locked shift and no till. Unchanged on a
-					normal open-shift dialog.
+					Hidden while a close is queued: go_desk() navigates to /app
+					and tears down the SPA, which on that path would strand the
+					cashier with a locked shift and no till. See can_exit_dialog
+					for the never-trap invariant that bounds this. Unchanged on
+					a normal open-shift dialog.
 				-->
 				<v-btn
-					v-if="!closingPending"
+					v-if="can_exit_dialog"
 					icon="mdi-close"
 					variant="text"
 					@click="go_desk"
@@ -148,10 +149,10 @@
 			<v-divider />
 			<v-card-actions class="px-6 py-4 enhanced-modal-header">
 				<v-spacer />
-				<!-- Same exit, same reason — hiding only the header X would leave
-					 the escape hatch wide open. -->
+				<!-- Same exit, same reason, same invariant — hiding only the
+					 header X would leave the escape hatch wide open. -->
 				<v-btn
-					v-if="!closingPending"
+					v-if="can_exit_dialog"
 					variant="text"
 					color="grey-darken-1"
 					@click="go_desk"
@@ -306,6 +307,24 @@ export default {
 			 */
 			cashModeForSelectedProfile() {
 				return this.denomination_config[this.pos_profile]?.cash_mode || "Cash";
+			},
+
+			/**
+			 * INVARIANT: this dialog must never present zero enabled controls.
+			 * It is `persistent`, so there is no click-away or Esc; both exits
+			 * (header X, Cancel) call the same `go_desk()`, and Submit is
+			 * disabled whenever `config_unavailable` — which is precisely the
+			 * offline-with-a-cold-cache case that follows an offline close. So
+			 * the closing-pending gate is lifted the moment Submit is
+			 * unusable: the cashier keeps a way forward, or a way out, always.
+			 *
+			 * `is_loading` deliberately does NOT lift the gate: it is transient,
+			 * self-clearing in submit_dialog's `finally`, and entered only by
+			 * the cashier's own action — not a trap, and flickering the exits
+			 * on every submit would be worse.
+			 */
+			can_exit_dialog() {
+				return !this.closingPending || this.config_unavailable;
 			},
 
 	},

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -7,7 +7,18 @@
 				<span class="text-h6 font-weight-bold text-primary">
 					{{ __("Create POS Opening Shift") }}
 				</span>
-				<v-btn icon="mdi-close" variant="text" @click="go_desk"></v-btn>
+				<!--
+					Hidden only while a close is queued: go_desk() navigates to
+					/app and tears down the SPA, which on that path would strand
+					the cashier with a locked shift and no till. Unchanged on a
+					normal open-shift dialog.
+				-->
+				<v-btn
+					v-if="!closingPending"
+					icon="mdi-close"
+					variant="text"
+					@click="go_desk"
+				></v-btn>
 			</v-card-title>
 
 			<v-card-text class="overflow-y-auto"
@@ -137,7 +148,14 @@
 			<v-divider />
 			<v-card-actions class="px-6 py-4 enhanced-modal-header">
 				<v-spacer />
-				<v-btn variant="text" color="grey-darken-1" @click="go_desk">
+				<!-- Same exit, same reason — hiding only the header X would leave
+					 the escape hatch wide open. -->
+				<v-btn
+					v-if="!closingPending"
+					variant="text"
+					color="grey-darken-1"
+					@click="go_desk"
+				>
 					{{ __("Cancel") }}
 				</v-btn>
 				<v-btn
@@ -162,7 +180,11 @@ import { toast } from "vue3-toastify";
 import { amountRules, isAmountValid } from "@/utils/validation";
 export default {
 	mixins: [format],
-	props: ["dialog"],
+	// `closingPending` comes in as a prop rather than over the eventBus: this
+	// dialog is `v-if`-ed into existence BY the offline-close path, so a
+	// `shift_closing_pending` event emitted there always fires before the
+	// component (and any listener it would register) exists.
+	props: ["dialog", "closingPending"],
 	data() {
 		return {
 			isOpen: this.dialog ? this.dialog : false,

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -267,13 +267,21 @@ export default {
 			const shift = snapshot?.pos_opening_shift;
 			if (!shift) return;
 			try {
-				// Pos.vue's mounted() can apply a cached opening snapshot
-				// before App.vue's mounted() finishes initOfflineStorage()
-				// (children mount before their parent in Vue's lifecycle,
-				// and App's init is async). initOfflineStorage() is
-				// idempotent — this either joins the in-flight init or
-				// no-ops if it already finished — so the write below never
-				// races the Dexie open / crypto key setup it depends on.
+				// initOfflineStorage() is already kicked off by App.vue's
+				// mounted() well before Pos.vue exists (routes are
+				// lazy-loaded and app.mount() does not await
+				// router.isReady()), so init has normally already STARTED
+				// by the time this fires. The real hazard is that it can
+				// still be IN FLIGHT: Dexie's db.open() and the crypto key
+				// bootstrap are real IndexedDB / Web Crypto round trips.
+				// initOfflineStorage() is idempotent (cached `initialised`
+				// flag + cached `initPromise`), so awaiting it here just
+				// joins whichever init is already running rather than
+				// starting a second db.open() or re-key — the write below
+				// can never race the storage it depends on. It also
+				// guarantees seedDeviceId() (which runs first inside init)
+				// has already run, so readDeviceId() below returns a real
+				// id instead of "unknown-device".
 				const { initOfflineStorage } = await import("@/offline/db");
 				await initOfflineStorage();
 				const { registerOpenedShift } = await import(
@@ -283,19 +291,65 @@ export default {
 				(shift.balance_details || []).forEach((row) => {
 					openingCashByMop[row.mode_of_payment] = Number(row.amount) || 0;
 				});
-				this.shiftLifecycleId = await registerOpenedShift({
-					openingServerName: shift.pos_offline_id ? null : shift.name || null,
+				const lifecycleId = await registerOpenedShift({
+					// `pos_offline_id` is a PERSISTED server custom field: it
+					// stays set forever once an offline-opened shift syncs,
+					// so it cannot distinguish "unsynced" from "synced".
+					// `pospire_pending_sync` is the client-side flag the
+					// onSynced handler actually clears; the server never
+					// returns this field at all, so a genuinely
+					// online-opened shift is also (correctly) falsy here.
+					openingServerName: shift.pospire_pending_sync
+						? null
+						: shift.name || null,
 					posProfile: snapshot.pos_profile || {},
 					openingCashByMop,
 					cashierUser: shift.user || window.user || "",
 					deviceId: readDeviceId(),
+					// Durable identity for the unsynced-offline case, where
+					// openingServerName above is null and there is nothing
+					// else stable to dedupe on across reloads.
+					lifecycleId: shift.pos_offline_id || undefined,
 				});
-				// Task 9's lock reads this off the in-memory shift.
-				if (this.pos_opening_shift) {
-					this.pos_opening_shift.pospire_lifecycle_id = this.shiftLifecycleId;
+				this.shiftLifecycleId = lifecycleId;
+				// Task 9's lock reads this off the in-memory shift. Guard
+				// against a second, differently-shifted call (cached
+				// snapshot vs. live response race in check_opening_entry)
+				// resolving out of order and stamping this shift's UUID onto
+				// whatever shift is now current.
+				if (this.pos_opening_shift === shift) {
+					shift.pospire_lifecycle_id = lifecycleId;
+					this.restampOpeningSnapshotCache(shift, lifecycleId);
 				}
 			} catch (err) {
 				console.warn("[Pos] registerShiftLifecycle failed", err);
+			}
+		},
+		// `persistOpeningSnapshot` runs synchronously right after
+		// `registerShiftLifecycle` is fired (fire-and-forget), so the
+		// cached snapshot is always written BEFORE the async lookup above
+		// resolves and stamps `pospire_lifecycle_id` in memory. Without
+		// this, the id would never survive a reload — exactly when Task 9
+		// needs to read it back. Patches the cache in place the same way
+		// the onSynced handler further below already does.
+		restampOpeningSnapshotCache(shift, lifecycleId) {
+			try {
+				const raw = localStorage.getItem("pospire.opening_shift_snapshot");
+				if (!raw) return;
+				const cached = JSON.parse(raw);
+				const cachedShift = cached?.pos_opening_shift;
+				if (!cachedShift) return;
+				const sameShift = shift.pos_offline_id
+					? cachedShift.pos_offline_id === shift.pos_offline_id
+					: cachedShift.name === shift.name;
+				if (!sameShift) return;
+				cachedShift.pospire_lifecycle_id = lifecycleId;
+				localStorage.setItem(
+					"pospire.opening_shift_snapshot",
+					JSON.stringify(cached),
+				);
+			} catch {
+				/* localStorage parse failure is non-fatal */
 			}
 		},
 		create_opening_voucher() {

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -451,6 +451,12 @@ export default {
 				: [];
 			const cashMode =
 				(this.pos_profile && this.pos_profile.posa_cash_mode_of_payment) || "Cash";
+			// Same source `utils/format.js` reads at mount (`this.currency_precision`)
+			// — Pos.vue doesn't mix that helper in, so read the site value directly
+			// rather than hardcoding 2. A 3-decimal currency (KWD, BHD, OMR) would
+			// otherwise get every queued payment silently rounded to 2dp here while
+			// the server keeps full precision.
+			const precision = window.sys_defaults?.currency_precision || 2;
 
 			// Stopgap — offline-queued sales only. Does NOT recover takings
 			// from earlier in the shift while online; that needs the Phase 2
@@ -465,7 +471,7 @@ export default {
 					openingServerName: opening.pos_offline_id ? null : opening.name || null,
 					shiftOfflineId: opening.pos_offline_id || null,
 					cashMode,
-					precision: 2,
+					precision,
 				});
 			} catch (err) {
 				console.warn("[Pos] queued payment sum failed", err);

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -226,6 +226,39 @@ export default {
 			}
 		},
 
+		/**
+		 * Drop the cached opening snapshot when reconciliation released the very
+		 * shift it names.
+		 *
+		 * A released shift is one whose closing already landed server-side, so
+		 * selling against it is invalid — but `isSellingBlocked` correctly stops
+		 * blocking the moment it stops being `closed_pending_sync`. Offline,
+		 * `check_opening_shift` can't be reached to contradict the snapshot, so
+		 * without this the next boot re-applies that shift UNLOCKED and rings
+		 * invoices against a closed shift. The old code got this for free by
+		 * nulling the snapshot at close time; that null-out had to go, so the
+		 * guard is re-established here from the durable reconciliation result.
+		 */
+		dropSnapshotForReleasedShifts(releasedIds) {
+			if (!Array.isArray(releasedIds) || !releasedIds.length) return;
+			try {
+				const raw = localStorage.getItem("pospire.opening_shift_snapshot");
+				if (!raw) return;
+				const cachedShift = JSON.parse(raw)?.pos_opening_shift;
+				if (!cachedShift) return;
+				// Same two keys registerOpenedShift dedupes on, in the same order.
+				const cachedId =
+					cachedShift.pospire_lifecycle_id || cachedShift.pos_offline_id;
+				if (!cachedId || !releasedIds.includes(cachedId)) return;
+				this.invalidateOpeningSnapshot(
+					"pospire.opening_shift_snapshot",
+					"pospire.opening_shift_snapshot.meta",
+				);
+			} catch {
+				/* private mode / corrupt cache — non-fatal */
+			}
+		},
+
 		openingSnapshotDiffers(cached, live) {
 			if (!cached) return true;
 			if (
@@ -494,9 +527,12 @@ export default {
 					shift_lifecycle_id: this.shiftLifecycleId,
 					closing_offline_id: r.offline_id,
 				});
-				// The snapshot is deliberately left pointing at the closing shift:
-				// it still carries `pospire_lifecycle_id`, which is how the lock
-				// re-resolves against the shift row after a reload.
+				// The snapshot is deliberately left pointing at the closing shift so
+				// the next boot can still find it. The lock is NOT re-derived from
+				// the snapshot's `pospire_lifecycle_id`: registerShiftLifecycle()
+				// re-derives the id through registerOpenedShift()'s dedupe and
+				// re-emits from getShiftById(). The stamp is only a fallback for
+				// Invoice.isShiftLocked().
 				this.pos_opening_shift = "";
 				this.create_opening_voucher();
 				return;
@@ -742,6 +778,9 @@ export default {
 				.then(({ reconcilePendingClosuresFromOutbox }) =>
 					reconcilePendingClosuresFromOutbox(),
 				)
+				.then((result) => {
+					this.dropSnapshotForReleasedShifts(result?.released);
+				})
 				.catch((err) => {
 					console.warn("[Pos] pending-closure reconciliation failed", err);
 				})
@@ -753,6 +792,21 @@ export default {
 				this.dialog = false;
 			});
 			this.eventBus.on("register_pos_data", (data) => {
+				// FIRST, before anything can observe the new shift. `pos_opening_shift`
+				// below is assigned synchronously but `shiftLifecycleId` is only
+				// assigned tens of ms later, inside registerShiftLifecycle(), after
+				// initOfflineStorage() + registerOpenedShift(). If the previous
+				// shift's closing syncs inside that gap — and that gap IS a reconnect,
+				// which is exactly when both happen at once — the onSynced handler's
+				// `resolved.shiftLifecycleId === this.shiftLifecycleId` would still
+				// match the OLD shift and wipe the one just opened. Nulling first
+				// makes that comparison unmatchable during the gap.
+				// `pendingClosingOfflineId` is cleared for a different reason: it
+				// gates the opening dialog's exits, and a closing parked in
+				// needs_review / handed_off can sit there indefinitely — a new shift
+				// must end the exit-less state.
+				this.shiftLifecycleId = null;
+				this.pendingClosingOfflineId = null;
 				this.pos_profile = data.pos_profile;
 				this.get_offers(this.pos_profile.name);
 				this.pos_opening_shift = data.pos_opening_shift;
@@ -884,7 +938,10 @@ export default {
 							const { resolveClosingSynced } = await import(
 								"@/offline/shift-lifecycle"
 							);
-							resolved = await resolveClosingSynced(event.offline_id);
+							resolved = await resolveClosingSynced(
+								event.offline_id,
+								event.server_doc_name ?? null,
+							);
 						} catch (err) {
 							console.warn("[Pos] resolveClosingSynced failed", err);
 							return;

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -7,7 +7,17 @@
 		<NewAddress></NewAddress>
 		<MpesaPayments></MpesaPayments>
 		<Variants></Variants>
-		<OpeningDialog v-if="dialog" :dialog="dialog"></OpeningDialog>
+		<!--
+			`closing-pending` is passed as a prop rather than signalled over the
+			eventBus: the dialog is `v-if`-ed into existence BY the close path,
+			so a `shift_closing_pending` event emitted there always fires
+			before this component exists and its listener would never run.
+		-->
+		<OpeningDialog
+			v-if="dialog"
+			:dialog="dialog"
+			:closing-pending="!!pendingClosingOfflineId"
+		></OpeningDialog>
 
 		<!-- Modal Components -->
 		<CouponsModal v-model="showCouponsModal"></CouponsModal>
@@ -242,13 +252,9 @@ export default {
 			this.get_offers(this.pos_profile.name);
 			this.eventBus.emit("register_pos_profile", snapshot);
 			this.eventBus.emit("set_company", snapshot.company);
-			if (snapshot.pos_opening_shift?.pospire_closing_pending) {
-				this.eventBus.emit("shift_closing_pending", {
-					shift_offline_id: snapshot.pos_opening_shift?.pos_offline_id,
-					closing_offline_id:
-						snapshot.pos_opening_shift?.pospire_pending_closing_offline_id,
-				});
-			}
+			// Closing-pending is no longer read off the snapshot — it lives on
+			// the durable shift row and is re-announced by
+			// registerShiftLifecycle() once the row has been looked up.
 			try {
 				setBeaconContext({
 					outlet:
@@ -284,7 +290,7 @@ export default {
 				// id instead of "unknown-device".
 				const { initOfflineStorage } = await import("@/offline/db");
 				await initOfflineStorage();
-				const { registerOpenedShift } = await import(
+				const { getShiftById, registerOpenedShift } = await import(
 					"@/offline/shift-lifecycle"
 				);
 				const openingCashByMop = {};
@@ -320,6 +326,28 @@ export default {
 				if (this.pos_opening_shift === shift) {
 					shift.pospire_lifecycle_id = lifecycleId;
 					this.restampOpeningSnapshotCache(shift, lifecycleId);
+				}
+
+				// Durable closing-pending state, re-announced. After a reload
+				// no `shift_closing_pending` event has ever fired in this
+				// session, so the shift row is the only thing that knows this
+				// shift is closing. Re-emitting rehydrates every in-session
+				// listener (cart lock, opening-dialog exit gate) from it.
+				// Deliberately LAST in the try: a decrypt failure here must not
+				// cost us the lifecycle-id stamping above.
+				const row = await getShiftById(lifecycleId);
+				if (row?.status === "closed_pending_sync") {
+					this.pendingClosingOfflineId = row.pending_closing_offline_id;
+					this.eventBus.emit("shift_closing_pending", {
+						shift_lifecycle_id: lifecycleId,
+						closing_offline_id: row.pending_closing_offline_id,
+					});
+					// The shift stays applied so the durable lock keeps
+					// resolving against it, but the cashier needs a route to a
+					// working till — otherwise a reload during a queued close
+					// strands them on a shift they can neither sell on nor
+					// close again.
+					this.create_opening_voucher();
 				}
 			} catch (err) {
 				console.warn("[Pos] registerShiftLifecycle failed", err);
@@ -439,52 +467,36 @@ export default {
 				this.check_opening_entry();
 				return;
 			}
-				if (r && r.offline === true && r.status === "enqueued") {
-					this.pendingClosingOfflineId = r.offline_id;
-					toast.info(
-						__("Shift close queued. It will finalise once every invoice in this shift has synced."),
-						{ autoClose: 5000 },
-					);
-				if (this.pos_opening_shift) {
-					this.pos_opening_shift = {
-						...this.pos_opening_shift,
-						pospire_closing_pending: true,
-						pospire_pending_closing_offline_id: r.offline_id,
-					};
+			if (r && r.offline === true && r.status === "enqueued") {
+				// Durable closing-pending state. The old code wrote a marker into
+				// the opening-shift snapshot and then nulled that same snapshot six
+				// lines later, so every reload-time recovery hook was dead: the
+				// sales lock evaporated and the queued close became invisible on
+				// refresh. State now lives on the shift row, which can also
+				// represent "A is closing while B is already open" — the normal
+				// state right after this branch routes the cashier to the dialog.
+				if (this.shiftLifecycleId) {
 					try {
-						const raw = localStorage.getItem("pospire.opening_shift_snapshot");
-						if (raw) {
-							const cached = JSON.parse(raw);
-							if (cached?.pos_opening_shift) {
-								cached.pos_opening_shift.pospire_closing_pending = true;
-								cached.pos_opening_shift.pospire_pending_closing_offline_id = r.offline_id;
-								localStorage.setItem(
-									"pospire.opening_shift_snapshot",
-									JSON.stringify(cached),
-								);
-							}
-						}
-					} catch {
-						/* non-fatal */
+						const { markShiftClosingPending } = await import(
+							"@/offline/shift-lifecycle"
+						);
+						await markShiftClosingPending(this.shiftLifecycleId, r.offline_id);
+					} catch (err) {
+						console.warn("[Pos] markShiftClosingPending failed", err);
 					}
 				}
+				this.pendingClosingOfflineId = r.offline_id;
+				toast.info(
+					__("Shift close queued. It will finalise once every invoice in this shift has synced."),
+					{ autoClose: 5000 },
+				);
 				this.eventBus.emit("shift_closing_pending", {
-					shift_offline_id: this.pos_opening_shift?.pos_offline_id,
+					shift_lifecycle_id: this.shiftLifecycleId,
 					closing_offline_id: r.offline_id,
 				});
-				try {
-					const raw = localStorage.getItem("pospire.opening_shift_snapshot");
-					if (raw) {
-						const cached = JSON.parse(raw);
-						cached.pos_opening_shift = null;
-						localStorage.setItem(
-							"pospire.opening_shift_snapshot",
-							JSON.stringify(cached),
-						);
-					}
-				} catch {
-					/* non-fatal */
-				}
+				// The snapshot is deliberately left pointing at the closing shift:
+				// it still carries `pospire_lifecycle_id`, which is how the lock
+				// re-resolves against the shift row after a reload.
 				this.pos_opening_shift = "";
 				this.create_opening_voucher();
 				return;
@@ -718,7 +730,24 @@ export default {
 		});
 
 		this.$nextTick(function () {
-			this.check_opening_entry();
+			// Rebuild closing-pending state from the outbox BEFORE the shift
+			// check runs, so a reload lands in the right state instead of
+			// silently resuming selling on a shift that is already closing —
+			// or staying locked on one whose closing landed while the app was
+			// shut. The shift check is chained rather than merely sequenced:
+			// reconciliation is async, and check_opening_entry() reads the very
+			// rows it rewrites. Chained off `.finally` so an import or Dexie
+			// failure still boots the POS.
+			import("@/offline/shift-lifecycle")
+				.then(({ reconcilePendingClosuresFromOutbox }) =>
+					reconcilePendingClosuresFromOutbox(),
+				)
+				.catch((err) => {
+					console.warn("[Pos] pending-closure reconciliation failed", err);
+				})
+				.finally(() => {
+					this.check_opening_entry();
+				});
 			this.get_pos_setting();
 			this.eventBus.on("close_opening_dialog", () => {
 				this.dialog = false;
@@ -805,7 +834,7 @@ export default {
 			// to the real server doc name. Subsequent invoices stop needing
 			// the offline_id forwarding (Invoice.vue's get_invoice_doc only
 			// emits `pos_opening_shift_offline_id` when that field is set).
-			this._unsubShiftSync = onSynced((event) => {
+			this._unsubShiftSync = onSynced(async (event) => {
 				if (event.type === "opening_entry") {
 					if (!event.server_doc_name || !event.provisional_name) return;
 					if (
@@ -845,29 +874,42 @@ export default {
 				}
 
 					// H4: closing entry synced. The shift is now genuinely closed
-					// on the server. If the cashier is still on the locked shift,
-					// release the local lock and route to the opening dialog. If
-					// they already opened the next shift, keep that active shift
-					// untouched and just clear the pending-close marker.
+					// on the server. Key off the CLOSING's own offline_id: the old
+					// guard read the ACTIVE shift's pending marker, so a synced
+					// closing for shift A could reset shift B — and after a reload
+					// (marker gone) it matched nothing at all and silently returned.
 					if (event.type === "closing_entry") {
-						const expected =
-							this.pos_opening_shift?.pospire_pending_closing_offline_id ||
-							this.pendingClosingOfflineId;
-						if (!expected || expected !== event.offline_id) return;
-						const stillOnLockedShift =
-							this.pos_opening_shift?.pospire_pending_closing_offline_id ===
-							event.offline_id;
-						this.pendingClosingOfflineId = null;
+						let resolved = null;
+						try {
+							const { resolveClosingSynced } = await import(
+								"@/offline/shift-lifecycle"
+							);
+							resolved = await resolveClosingSynced(event.offline_id);
+						} catch (err) {
+							console.warn("[Pos] resolveClosingSynced failed", err);
+							return;
+						}
+						if (!resolved) return;
+
+						if (this.pendingClosingOfflineId === event.offline_id) {
+							this.pendingClosingOfflineId = null;
+						}
 						toast.success(__("Shift closed and synced"), { autoClose: 3000 });
 						this.eventBus.emit("shift_closing_complete", {
+							shift_lifecycle_id: resolved.shiftLifecycleId,
 							closing_offline_id: event.offline_id,
 							closing_server_name: event.server_doc_name,
 						});
-						if (stillOnLockedShift) {
+
+						// Route to the opening dialog only if the cashier is STILL on
+						// the shift that just closed. If they already opened the next
+						// one, leave it — and its snapshot — completely alone.
+						if (resolved.shiftLifecycleId === this.shiftLifecycleId) {
 							this.invalidateOpeningSnapshot(
 								"pospire.opening_shift_snapshot",
 								"pospire.opening_shift_snapshot.meta",
 							);
+							this.shiftLifecycleId = null;
 							this.pos_opening_shift = "";
 							this.pos_profile = "";
 							this.create_opening_voucher();

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -59,6 +59,7 @@ import Variants from "./Variants.vue";
 import Returns from "./Returns.vue";
 import MpesaPayments from "./Mpesa-Payments.vue";
 import { call, unwrapStale } from "@/utils/call";
+import { OPENING_DIALOG_CACHE_KEY } from "@/utils/call-registry";
 import { toast } from "vue3-toastify";
 import { onSynced } from "@/offline/outbox";
 import { setBeaconContext } from "@/offline/beacon";
@@ -120,6 +121,20 @@ export default {
 					user: window.user,
 				});
 				liveCallSucceeded = true;
+				// Warm the opening-dialog cache on every online boot, not
+				// only when the dialog opens. OpeningDialog is v-if="dialog"
+				// so it is constructed only when create_opening_voucher()
+				// fires; a terminal running all day on an open shift would
+				// otherwise reach the dialog (after an offline close) cold.
+				// Fire-and-forget: never block the shift check on this.
+				call({
+					method: "pospire.pospire.api.posapp.get_opening_dialog_data",
+					args: {},
+					intent: "read",
+					cacheKey: OPENING_DIALOG_CACHE_KEY,
+				}).catch(() => {
+					/* non-fatal — the dialog retries when it opens */
+				});
 				if (r) {
 					this.persistOpeningSnapshot(r, SNAPSHOT_KEY, SNAPSHOT_META_KEY);
 				}

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -276,6 +276,17 @@ export default {
 
 		applyOpeningSnapshot(snapshot) {
 			if (!snapshot?.pos_profile) return;
+			// Symmetric with the `register_pos_data` handler, and for the same
+			// reason: this is the OTHER door a shift change comes through
+			// (check_opening_entry when openingSnapshotDiffers), and it can
+			// carry a DIFFERENT shift than the one currently registered.
+			// `shiftLifecycleId` is only re-assigned tens of ms later by the
+			// async registerShiftLifecycle() below; during that gap a stale id
+			// would still satisfy the onSynced routing guard and wipe the shift
+			// just applied. Placed after the early return, not before it — a
+			// rejected snapshot changes no shift, so clearing the id there
+			// would blind the routing guard for a shift that is still current.
+			this.shiftLifecycleId = null;
 			this.pos_profile = snapshot.pos_profile;
 			this.pos_opening_shift = snapshot.pos_opening_shift;
 			// Every shift gets a durable row and a local lifecycle UUID,

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -438,24 +438,66 @@ export default {
 				);
 			} catch (err) {
 				console.warn("[Pos] make_closing_shift offline fallback", err);
-				r = this.buildOfflineClosingStub();
+				r = await this.buildOfflineClosingStub();
 			}
 			if (r) {
 				this.eventBus.emit("open_ClosingDialog", r);
 			}
 		},
-		buildOfflineClosingStub() {
+		async buildOfflineClosingStub() {
 			const opening = this.pos_opening_shift || {};
 			const balance = Array.isArray(opening.balance_details)
 				? opening.balance_details
 				: [];
-			const payment_reconciliation = balance.map((row) => ({
-				mode_of_payment: row.mode_of_payment,
-				opening_amount: row.amount || 0,
-				expected_amount: row.amount || 0,
-				closing_amount: 0,
-				difference: 0,
-			}));
+			const cashMode =
+				(this.pos_profile && this.pos_profile.posa_cash_mode_of_payment) || "Cash";
+
+			// Stopgap — offline-queued sales only. Does NOT recover takings
+			// from earlier in the shift while online; that needs the Phase 2
+			// contribution ledger. The dialog labels the result provisional
+			// precisely because of this gap.
+			let queued = { byMop: {}, uncertainCount: 0 };
+			try {
+				const { sumQueuedPaymentsByMop } = await import(
+					"@/offline/shift-lifecycle"
+				);
+				queued = await sumQueuedPaymentsByMop({
+					openingServerName: opening.pos_offline_id ? null : opening.name || null,
+					shiftOfflineId: opening.pos_offline_id || null,
+					cashMode,
+					precision: 2,
+				});
+			} catch (err) {
+				console.warn("[Pos] queued payment sum failed", err);
+			}
+
+			const seen = new Set();
+			const payment_reconciliation = balance.map((row) => {
+				seen.add(row.mode_of_payment);
+				const opening_amount = row.amount || 0;
+				return {
+					mode_of_payment: row.mode_of_payment,
+					opening_amount,
+					expected_amount:
+						opening_amount + (queued.byMop[row.mode_of_payment] || 0),
+					closing_amount: 0,
+					difference: 0,
+				};
+			});
+			// A MOP taken on an invoice but absent from balance_details gets
+			// its own row, mirroring the server's seen_mops handling. Dropping
+			// it would silently lose the amount.
+			Object.entries(queued.byMop).forEach(([mode_of_payment, amount]) => {
+				if (seen.has(mode_of_payment)) return;
+				payment_reconciliation.push({
+					mode_of_payment,
+					opening_amount: 0,
+					expected_amount: amount,
+					closing_amount: 0,
+					difference: 0,
+				});
+			});
+
 			return {
 				name: "",
 				pos_opening_shift: opening.name || "",
@@ -472,6 +514,7 @@ export default {
 				taxes: [],
 				denomination_details: opening.denomination_details || [],
 				pospire_offline_stub: true,
+				pospire_uncertain_count: queued.uncertainCount,
 			};
 		},
 		async submit_closing_pos(data) {

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -162,8 +162,18 @@ export default {
 				if (!registeredFromCache || this.openingSnapshotDiffers(cachedSnapshot, r)) {
 					this.applyOpeningSnapshot(r);
 				} else {
+					// The live response is a DIFFERENT object for the same shift
+					// and the server does not echo `pospire_lifecycle_id`, so a
+					// bare reassignment drops a stamp the cached snapshot was
+					// already carrying — leaving Invoice.isShiftLocked() with
+					// nothing to key on until registerShiftLifecycle() resolves.
+					// Carry it across explicitly rather than relying on that race.
+					const stamped = this.pos_opening_shift?.pospire_lifecycle_id;
 					this.pos_profile = r.pos_profile;
 					this.pos_opening_shift = r.pos_opening_shift;
+					if (stamped && this.pos_opening_shift && !this.pos_opening_shift.pospire_lifecycle_id) {
+						this.pos_opening_shift.pospire_lifecycle_id = stamped;
+					}
 				}
 				console.info("LoadPosProfile");
 			} else if (liveCallSucceeded && !cachedSnapshot?.pos_opening_shift?.pospire_pending_sync) {
@@ -356,10 +366,16 @@ export default {
 					openingCashByMop,
 					cashierUser: shift.user || window.user || "",
 					deviceId: readDeviceId(),
-					// Durable identity for the unsynced-offline case, where
-					// openingServerName above is null and there is nothing
-					// else stable to dedupe on across reloads.
-					lifecycleId: shift.pos_offline_id || undefined,
+					// Durable identity of this shift's row. `pos_offline_id`
+					// covers the unsynced-offline case; `pospire_lifecycle_id`
+					// covers every other case, INCLUDING a shift opened offline
+					// and synced mid-shift, whose `pos_offline_id` the sync
+					// handler has since cleared. Passing it on the online path
+					// too is deliberate: registerOpenedShift tries the server
+					// name first and this second, so the row is still found
+					// when its `opening_server_name` never landed.
+					lifecycleId:
+						shift.pos_offline_id || shift.pospire_lifecycle_id || undefined,
 				});
 				this.shiftLifecycleId = lifecycleId;
 				// Task 9's lock reads this off the in-memory shift. Guard
@@ -367,8 +383,29 @@ export default {
 				// snapshot vs. live response race in check_opening_entry)
 				// resolving out of order and stamping this shift's UUID onto
 				// whatever shift is now current.
-				if (this.pos_opening_shift === shift) {
+				//
+				// The guard is a VALUE comparison, not object identity. On the
+				// `registeredFromCache && !openingSnapshotDiffers` path,
+				// check_opening_entry reassigns `pos_opening_shift` to the live
+				// response — a different object describing the SAME shift — so
+				// an identity check simply lost the race whenever the network
+				// beat the Dexie write. Losing it meant no `pospire_lifecycle_id`
+				// stamp (durable cart lock inert for the whole session) and no
+				// restampOpeningSnapshotCache (released-shift snapshot
+				// invalidation never fires, since it falls back to
+				// `pos_offline_id`, which an online-opened shift never has).
+				// Every device with a shift open at upgrade time takes that
+				// path on its first reload. Same predicate
+				// restampOpeningSnapshotCache uses: `pos_offline_id` else `name`.
+				if (this.sameShift(this.pos_opening_shift, shift)) {
 					shift.pospire_lifecycle_id = lifecycleId;
+					// Stamp the currently-mounted object too when it is a
+					// different instance of the same shift — Invoice.vue holds
+					// the one it was handed via `register_pos_profile`, while
+					// buildOfflineClosingStub reads this one.
+					if (this.pos_opening_shift !== shift) {
+						this.pos_opening_shift.pospire_lifecycle_id = lifecycleId;
+					}
 					this.restampOpeningSnapshotCache(shift, lifecycleId);
 				}
 
@@ -397,6 +434,30 @@ export default {
 				console.warn("[Pos] registerShiftLifecycle failed", err);
 			}
 		},
+		/**
+		 * Do these two shift objects describe the SAME shift?
+		 *
+		 * Value predicate, deliberately not `===`: the cached snapshot and the
+		 * live `check_opening_shift` response are always distinct objects for
+		 * the same shift, and every guard that used identity instead silently
+		 * no-opped whenever the live response arrived first.
+		 *
+		 * `pos_offline_id` is preferred because a shift opened offline is
+		 * renamed on sync (provisional -> server name), so `name` is not stable
+		 * across that boundary; once it IS synced `pos_offline_id` is cleared
+		 * on both sides and `name` is. An offline id on ONE side only means the
+		 * two are at different points across that rename, which is a mismatch
+		 * — falling back to `name` there would compare a provisional name
+		 * against a server one and never match anyway.
+		 */
+		sameShift(a, b) {
+			if (!a || !b) return false;
+			if (a === b) return true;
+			if (a.pos_offline_id || b.pos_offline_id) {
+				return !!a.pos_offline_id && a.pos_offline_id === b.pos_offline_id;
+			}
+			return !!a.name && a.name === b.name;
+		},
 		// `persistOpeningSnapshot` runs synchronously right after
 		// `registerShiftLifecycle` is fired (fire-and-forget), so the
 		// cached snapshot is always written BEFORE the async lookup above
@@ -411,10 +472,7 @@ export default {
 				const cached = JSON.parse(raw);
 				const cachedShift = cached?.pos_opening_shift;
 				if (!cachedShift) return;
-				const sameShift = shift.pos_offline_id
-					? cachedShift.pos_offline_id === shift.pos_offline_id
-					: cachedShift.name === shift.name;
-				if (!sameShift) return;
+				if (!this.sameShift(cachedShift, shift)) return;
 				cachedShift.pospire_lifecycle_id = lifecycleId;
 				localStorage.setItem(
 					"pospire.opening_shift_snapshot",
@@ -467,9 +525,22 @@ export default {
 				const { sumQueuedPaymentsByMop } = await import(
 					"@/offline/shift-lifecycle"
 				);
+				// BOTH anchors, always — sumQueuedPaymentsByMop matches on
+				// either. A shift opened offline and synced mid-shift has
+				// invoices on both sides of the sync: the pre-sync ones are
+				// stamped with `shift_offline_id` (= the lifecycle id, since
+				// the row is keyed by the opening's outbox id) and the
+				// post-sync ones carry only the server name. Passing just one
+				// anchor dropped a whole half of the shift's takings.
+				// `pospire_lifecycle_id` is the offline id's stand-in after the
+				// sync handler clears `pos_offline_id`; on an online-opened
+				// shift it is a UUID no outbox row carries, which simply
+				// matches nothing and leaves the server-name clause to do the
+				// work.
 				queued = await sumQueuedPaymentsByMop({
-					openingServerName: opening.pos_offline_id ? null : opening.name || null,
-					shiftOfflineId: opening.pos_offline_id || null,
+					openingServerName: opening.name || null,
+					shiftOfflineId:
+						opening.pos_offline_id || opening.pospire_lifecycle_id || null,
 					cashMode,
 					precision,
 				});
@@ -839,6 +910,12 @@ export default {
 					reconcilePendingClosuresFromOutbox(),
 				)
 				.then((result) => {
+					// `released` ONLY — deliberately not `result.reopened`. A
+					// reopened shift is one whose closing was voided, so it is
+					// still Open server-side and its snapshot is the thing that
+					// lets the cashier resume on it. Dropping that snapshot is
+					// what used to strand them in the opening dialog and get a
+					// second shift opened against the first.
 					this.dropSnapshotForReleasedShifts(result?.released);
 				})
 				.catch((err) => {
@@ -951,10 +1028,40 @@ export default {
 			this._unsubShiftSync = onSynced(async (event) => {
 				if (event.type === "opening_entry") {
 					if (!event.server_doc_name || !event.provisional_name) return;
+					// FIRST: give the durable shift row its server identity. The
+					// row was created keyed only by this opening's outbox id
+					// (`event.offline_id` === the shift row's `offline_id`), with
+					// `opening_server_name: null`. Everything below clears
+					// `pos_offline_id` from memory and from the snapshot, so
+					// after the next reload the shift looks like an ordinary
+					// server-named one — and without this write its row could not
+					// be found by that name, a SECOND `open` row was created, and
+					// any queued close stopped applying to the shift the cashier
+					// was on. Status is preserved by attachOpeningServerName: the
+					// close may already be queued by the time the opening lands.
+					try {
+						const { attachOpeningServerName } = await import(
+							"@/offline/shift-lifecycle"
+						);
+						await attachOpeningServerName(
+							event.offline_id,
+							event.server_doc_name,
+						);
+					} catch (err) {
+						console.warn("[Pos] attachOpeningServerName failed", err);
+					}
 					if (
 						this.pos_opening_shift &&
 						this.pos_opening_shift.name === event.provisional_name
 					) {
+						// Keep the lifecycle id reachable after `pos_offline_id`
+						// goes: it is the only remaining handle on the durable row
+						// (and on this shift's pre-sync outbox rows) once the
+						// offline id is cleared below.
+						if (!this.pos_opening_shift.pospire_lifecycle_id) {
+							this.pos_opening_shift.pospire_lifecycle_id =
+								this.pos_opening_shift.pos_offline_id || event.offline_id;
+						}
 						this.pos_opening_shift.name = event.server_doc_name;
 						this.pos_opening_shift.pos_offline_id = null;
 						this.pos_opening_shift.pospire_pending_sync = false;
@@ -968,6 +1075,15 @@ export default {
 							if (
 								cached?.pos_opening_shift?.name === event.provisional_name
 							) {
+								// Same reason as the in-memory patch above: this is
+								// the last chance to persist the durable row's id
+								// before `pos_offline_id` is cleared out of the
+								// snapshot, and the next boot's dedupe reads it.
+								if (!cached.pos_opening_shift.pospire_lifecycle_id) {
+									cached.pos_opening_shift.pospire_lifecycle_id =
+										cached.pos_opening_shift.pos_offline_id ||
+										event.offline_id;
+								}
 								cached.pos_opening_shift.name = event.server_doc_name;
 								cached.pos_opening_shift.pos_offline_id = null;
 								cached.pos_opening_shift.pospire_pending_sync = false;

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -61,7 +61,7 @@ import MpesaPayments from "./Mpesa-Payments.vue";
 import { call, unwrapStale } from "@/utils/call";
 import { OPENING_DIALOG_CACHE_KEY } from "@/utils/call-registry";
 import { toast } from "vue3-toastify";
-import { onSynced } from "@/offline/outbox";
+import { onSynced, readDeviceId } from "@/offline/outbox";
 import { setBeaconContext } from "@/offline/beacon";
 import connectivity from "@/offline/connectivity";
 
@@ -78,6 +78,7 @@ export default {
 				pendingMasterDataRefresh: { items: false, customers: false },
 				cartHasItems: false,
 				pendingClosingOfflineId: null,
+				shiftLifecycleId: null,
 			};
 		},
 
@@ -234,6 +235,10 @@ export default {
 			if (!snapshot?.pos_profile) return;
 			this.pos_profile = snapshot.pos_profile;
 			this.pos_opening_shift = snapshot.pos_opening_shift;
+			// Every shift gets a durable row and a local lifecycle UUID,
+			// online-opened ones included. Fire-and-forget: a Dexie failure
+			// must never block the POS from loading.
+			this.registerShiftLifecycle(snapshot);
 			this.get_offers(this.pos_profile.name);
 			this.eventBus.emit("register_pos_profile", snapshot);
 			this.eventBus.emit("set_company", snapshot.company);
@@ -257,6 +262,41 @@ export default {
 				console.warn("[Pos] setBeaconContext failed", err);
 			}
 			this.warm_customer_form_options_cache();
+		},
+		async registerShiftLifecycle(snapshot) {
+			const shift = snapshot?.pos_opening_shift;
+			if (!shift) return;
+			try {
+				// Pos.vue's mounted() can apply a cached opening snapshot
+				// before App.vue's mounted() finishes initOfflineStorage()
+				// (children mount before their parent in Vue's lifecycle,
+				// and App's init is async). initOfflineStorage() is
+				// idempotent — this either joins the in-flight init or
+				// no-ops if it already finished — so the write below never
+				// races the Dexie open / crypto key setup it depends on.
+				const { initOfflineStorage } = await import("@/offline/db");
+				await initOfflineStorage();
+				const { registerOpenedShift } = await import(
+					"@/offline/shift-lifecycle"
+				);
+				const openingCashByMop = {};
+				(shift.balance_details || []).forEach((row) => {
+					openingCashByMop[row.mode_of_payment] = Number(row.amount) || 0;
+				});
+				this.shiftLifecycleId = await registerOpenedShift({
+					openingServerName: shift.pos_offline_id ? null : shift.name || null,
+					posProfile: snapshot.pos_profile || {},
+					openingCashByMop,
+					cashierUser: shift.user || window.user || "",
+					deviceId: readDeviceId(),
+				});
+				// Task 9's lock reads this off the in-memory shift.
+				if (this.pos_opening_shift) {
+					this.pos_opening_shift.pospire_lifecycle_id = this.shiftLifecycleId;
+				}
+			} catch (err) {
+				console.warn("[Pos] registerShiftLifecycle failed", err);
+			}
 		},
 		create_opening_voucher() {
 			this.dialog = true;
@@ -633,6 +673,7 @@ export default {
 				this.pos_profile = data.pos_profile;
 				this.get_offers(this.pos_profile.name);
 				this.pos_opening_shift = data.pos_opening_shift;
+				this.registerShiftLifecycle(data);
 				this.eventBus.emit("register_pos_profile", data);
 				if (data.pos_profile && data.company) {
 					this.persistOpeningSnapshot(

--- a/frontend/src/offline/outbox.ts
+++ b/frontend/src/offline/outbox.ts
@@ -930,6 +930,17 @@ export async function countPending(): Promise<number> {
 }
 
 /**
+ * Sync-state of every queued closing entry, read off plaintext columns only.
+ * See `repos/outbox.listClosingEntryStatuses` for why this is not a set of
+ * `listByStatus()` sweeps.
+ */
+export async function listClosingEntryStatuses(): ReturnType<
+	typeof outboxRepo.listClosingEntryStatuses
+> {
+	return outboxRepo.listClosingEntryStatuses();
+}
+
+/**
  * Edit & Retry: mutate the queued payload, re-encrypt, recompute integrity hash,
  * reset status to enqueued, and wake the scheduler. Refuses on voided/synced rows.
  */

--- a/frontend/src/offline/outbox.ts
+++ b/frontend/src/offline/outbox.ts
@@ -1024,7 +1024,13 @@ export async function resetForRetry(offlineId: string): Promise<void> {
 // Utilities
 // ---------------------------------------------------------------------------
 
-function readDeviceId(): string {
+/**
+ * Exported so `shift-lifecycle.ts` (and any other module that needs to
+ * stamp a device id outside the outbox's own enqueue path) reuses this
+ * exact fallback logic instead of growing a second copy. `audit-export.ts`
+ * still carries its own pre-existing duplicate; not touched here.
+ */
+export function readDeviceId(): string {
 	try {
 		if (typeof localStorage !== "undefined") {
 			return localStorage.getItem(LS_DEVICE_ID) ?? "unknown-device";

--- a/frontend/src/offline/outbox.ts
+++ b/frontend/src/offline/outbox.ts
@@ -925,6 +925,17 @@ export async function listByStatus<T = unknown>(
 	return outboxRepo.listByStatus<T>(status);
 }
 
+/**
+ * Invoice rows across several statuses, resilient to a single corrupt row —
+ * see `repos/outbox.listInvoiceRowsAcrossStatuses` for why this exists
+ * instead of composing `listByStatus` calls.
+ */
+export async function listInvoiceRowsAcrossStatuses(
+	statuses: OutboxStatus[],
+): ReturnType<typeof outboxRepo.listInvoiceRowsAcrossStatuses> {
+	return outboxRepo.listInvoiceRowsAcrossStatuses(statuses);
+}
+
 export async function countPending(): Promise<number> {
 	return outboxRepo.countPending();
 }

--- a/frontend/src/offline/outbox.ts
+++ b/frontend/src/offline/outbox.ts
@@ -45,6 +45,11 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
+/** Matches a UUID v4 string (e.g. an offline_id). Used to distinguish a
+ * provisional offline shift reference from a real server doc name. */
+const UUID_V4_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 /** The 8 valid outbox types (mirrors `OutboxType`). Runtime-guard for the
  * loosely-typed `call-registry.ts` `outboxType: string` field. */
 const VALID_TYPES = new Set<OutboxType>([
@@ -783,10 +788,14 @@ export async function evaluateClosingReadiness(
  * Best-effort extraction of the inner doc's `posa_pos_opening_shift` from
  * an outbox payload. Outbox payloads for offline-capable writes use the
  * wrapper shape `{ data: "<JSON inner doc>", … }`; for non-wrapper shapes
- * (legacy entries) we read the field directly. Returns `null` if neither
- * shape produces a string.
+ * (legacy entries) we read the field directly. Falls back to the wrapper's
+ * `opening_entry_ref` (excluding UUIDs, which anchor offline-opened shifts
+ * via `shift_offline_id` instead) for rows queued before the inner doc
+ * carried the shift name. Returns `null` if nothing usable is found.
+ *
+ * Exported: Task 10 imports this by name from `@/offline/outbox`.
  */
-function readInnerShiftName(payload: unknown): string | null {
+export function readInnerShiftName(payload: unknown): string | null {
 	if (!payload || typeof payload !== "object") return null;
 	const p = payload as Record<string, unknown>;
 	if (typeof p.data === "string") {
@@ -795,15 +804,26 @@ function readInnerShiftName(payload: unknown): string | null {
 			const name =
 				(inner.posa_pos_opening_shift as string | undefined) ??
 				(inner.pos_opening_shift as string | undefined);
-			return typeof name === "string" && name.length > 0 ? name : null;
+			if (typeof name === "string" && name.length > 0) return name;
 		} catch {
-			return null;
+			/* fall through to the wrapper */
 		}
+	} else {
+		const direct =
+			(p.posa_pos_opening_shift as string | undefined) ??
+			(p.pos_opening_shift as string | undefined);
+		if (typeof direct === "string" && direct.length > 0) return direct;
 	}
-	const direct =
-		(p.posa_pos_opening_shift as string | undefined) ??
-		(p.pos_opening_shift as string | undefined);
-	return typeof direct === "string" && direct.length > 0 ? direct : null;
+
+	// Back-compat: rows queued before the stamp landed carry the shift
+	// reference only on the wrapper. A UUID there means an OFFLINE-opened
+	// shift, which is anchored by `shift_offline_id` instead — returning it
+	// here would compare a UUID against a server name and never match.
+	const ref = p.opening_entry_ref;
+	if (typeof ref === "string" && ref.length > 0 && !UUID_V4_PATTERN.test(ref)) {
+		return ref;
+	}
+	return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/offline/read-cache.ts
+++ b/frontend/src/offline/read-cache.ts
@@ -87,10 +87,15 @@ const DURABLE_KEYS: ReadonlySet<string> = new Set([
 	"dashboard.shift", // shift dashboard cards + graph/table payload
 	"offline.customer_form_options", // territory / gender / customer-group lists
 	// Opening-dialog reference data: companies, POS profile names, POS Payment
-	// Method rows, denomination policy. No PII, no catalogue — qualifies under
-	// the allowlist contract above. Durable because the dialog is unusable
-	// without it and the cashier often reaches it only after a reload, offline.
-	// Do not widen get_opening_dialog_data's response without re-checking this.
+	// Method rows (server explicitly selects only `parent` + `mode_of_payment`
+	// — NOT fields=["*"], which would also return `owner`/`modified_by` staff
+	// emails, see pospire/pospire/api/posapp.py::get_opening_dialog_data),
+	// denomination policy. No PII, no catalogue — qualifies under the
+	// allowlist contract above. Durable because the dialog is unusable
+	// without it and the cashier often reaches it only after a reload,
+	// offline. Do not widen get_opening_dialog_data's response (server OR
+	// client side) without re-checking this — a future `fields=["*"]` or an
+	// added PII field on the doctype would silently defeat the allowlist.
 	"offline.opening_dialog_data",
 ]);
 

--- a/frontend/src/offline/read-cache.ts
+++ b/frontend/src/offline/read-cache.ts
@@ -60,6 +60,10 @@ export class InMemoryReadCache implements ReadCache {
 		});
 	}
 
+	async invalidate(cacheKey: string): Promise<void> {
+		this.store.delete(cacheKey);
+	}
+
 	/** Test/diagnostic: drop everything. */
 	clear(): void {
 		this.store.clear();
@@ -82,6 +86,12 @@ const RC_PREFIX = "rc:";
 const DURABLE_KEYS: ReadonlySet<string> = new Set([
 	"dashboard.shift", // shift dashboard cards + graph/table payload
 	"offline.customer_form_options", // territory / gender / customer-group lists
+	// Opening-dialog reference data: companies, POS profile names, POS Payment
+	// Method rows, denomination policy. No PII, no catalogue — qualifies under
+	// the allowlist contract above. Durable because the dialog is unusable
+	// without it and the cashier often reaches it only after a reload, offline.
+	// Do not widen get_opening_dialog_data's response without re-checking this.
+	"offline.opening_dialog_data",
 ]);
 
 export class DexieMetadataReadCache implements ReadCache {
@@ -132,6 +142,17 @@ export class DexieMetadataReadCache implements ReadCache {
 			} as MetadataRow<CacheEntry>);
 		} catch {
 			// Non-fatal — in-memory still covers this session.
+		}
+	}
+
+	/** Drop a single cached key from both layers. Used on logout. */
+	async invalidate(cacheKey: string): Promise<void> {
+		this.mem.delete(cacheKey);
+		if (!DURABLE_KEYS.has(cacheKey)) return;
+		try {
+			await db.metadata.delete(RC_PREFIX + cacheKey);
+		} catch {
+			/* non-fatal — the memory layer is already cleared */
 		}
 	}
 

--- a/frontend/src/offline/repos/outbox.ts
+++ b/frontend/src/offline/repos/outbox.ts
@@ -135,6 +135,31 @@ export async function listByType<T = unknown>(
 	return Promise.all(stored.map((s) => fromStored<T>(s)));
 }
 
+/**
+ * Plaintext `{ offline_id, status }` for every queued closing entry, WITHOUT
+ * decrypting a single payload.
+ *
+ * `type` is indexed and `status` is a plaintext scalar on `StoredOutboxEntry`,
+ * so the sync-state of a closing can be answered without `fromStored`. The
+ * alternative — five `listByStatus()` sweeps — decrypts EVERY unsynced row in
+ * the outbox (queued invoices, payments, customers) just to read two plaintext
+ * columns, and one undecryptable row aborts the lot. Closing reconciliation
+ * runs on the boot path and swallows its own errors, so an abort there leaves
+ * the app selling against a shift that is already closing.
+ */
+export async function listClosingEntryStatuses(): Promise<
+	Array<Pick<StoredOutboxEntry, "offline_id" | "status">>
+> {
+	const stored = await db.outbox
+		.where("type")
+		.equals("closing_entry")
+		.toArray();
+	return stored.map((row) => ({
+		offline_id: row.offline_id,
+		status: row.status,
+	}));
+}
+
 export async function listByShift<T = unknown>(
 	shiftOfflineId: string,
 ): Promise<OutboxEntry<T>[]> {

--- a/frontend/src/offline/repos/outbox.ts
+++ b/frontend/src/offline/repos/outbox.ts
@@ -160,6 +160,41 @@ export async function listClosingEntryStatuses(): Promise<
 	}));
 }
 
+/**
+ * Invoice rows across the given statuses, decrypted ROW-BY-ROW rather than
+ * with a single `Promise.all`.
+ *
+ * `listByStatus`'s `Promise.all(stored.map(fromStored))` rejects the ENTIRE
+ * bucket the instant any one row fails to decrypt (stale key, corrupted
+ * envelope). The shift-close aggregation (`sumQueuedPaymentsByMop` in
+ * `shift-lifecycle.ts`) scans six status buckets and sums every invoice it
+ * can read — if it were built on `listByStatus`, a single poison row in ANY
+ * bucket would throw, the caller's catch would swallow it, and the cashier's
+ * entire expected-amount figure would silently come back as zero across every
+ * mode of payment, not just the corrupt invoice's contribution. Skipping the
+ * bad row and continuing is strictly safer for a reconciliation figure than
+ * an all-or-nothing failure. `corruptCount` is returned so a caller can log
+ * or surface it; single-index scan by `type` (fewer types than statuses)
+ * keeps this cheap.
+ */
+export async function listInvoiceRowsAcrossStatuses(
+	statuses: OutboxStatus[],
+): Promise<{ rows: OutboxEntry<unknown>[]; corruptCount: number }> {
+	const statusSet = new Set(statuses);
+	const stored = await db.outbox.where("type").equals("invoice").toArray();
+	const rows: OutboxEntry<unknown>[] = [];
+	let corruptCount = 0;
+	for (const s of stored) {
+		if (!statusSet.has(s.status)) continue;
+		try {
+			rows.push(await fromStored(s));
+		} catch {
+			corruptCount += 1;
+		}
+	}
+	return { rows, corruptCount };
+}
+
 export async function listByShift<T = unknown>(
 	shiftOfflineId: string,
 ): Promise<OutboxEntry<T>[]> {

--- a/frontend/src/offline/repos/shifts.ts
+++ b/frontend/src/offline/repos/shifts.ts
@@ -84,6 +84,7 @@ async function toStored(row: ShiftRow): Promise<StoredShiftRow> {
 		variance_at_sync: row.variance_at_sync,
 		closed_at: row.closed_at,
 		closing_server_name: row.closing_server_name,
+		pending_closing_offline_id: row.pending_closing_offline_id,
 		status: row.status,
 		manager_approval_required: row.manager_approval_required,
 		opening_cash_envelope: opening,
@@ -133,6 +134,7 @@ async function fromStored(stored: StoredShiftRow): Promise<ShiftRow> {
 		closing_notes: notes,
 		closed_at: stored.closed_at,
 		closing_server_name: stored.closing_server_name,
+		pending_closing_offline_id: stored.pending_closing_offline_id,
 		status: stored.status,
 		manager_approval_required: stored.manager_approval_required,
 	};
@@ -201,6 +203,7 @@ export async function updateShiftStatus(
 			| "closed_at"
 			| "closing_server_name"
 			| "opening_server_name"
+			| "pending_closing_offline_id"
 			| "variance_at_sync"
 			| "manager_approval_required"
 		>

--- a/frontend/src/offline/repos/shifts.ts
+++ b/frontend/src/offline/repos/shifts.ts
@@ -251,10 +251,17 @@ export async function putShift(row: ShiftRow): Promise<void> {
 export { toStored as buildStoredShift };
 
 /**
- * Atomically register a PRE-ENCRYPTED stored row, deduping on either the
- * server name or a caller-supplied durable id (`lifecycleId`) — without
+ * Atomically register a PRE-ENCRYPTED stored row, deduping on the server
+ * name AND then on a caller-supplied durable id (`lifecycleId`) — without
  * decrypting anything. `stored` must already be the output of
  * `buildStoredShift`, produced OUTSIDE any transaction.
+ *
+ * BOTH keys are tried, in that order, rather than one or the other. A shift
+ * opened offline and synced mid-shift presents both: a server name (which
+ * its row may or may not have learned yet — `attachOpeningServerName` is
+ * best-effort) and its original outbox id. Checking only the server name
+ * missed that row and inserted a duplicate `open` one, which quietly
+ * detached the shift from its own `closed_pending_sync` state.
  *
  * Both dedupe checks compare plaintext scalars already present on
  * `StoredShiftRow` (`opening_server_name`, the `offline_id` primary key),
@@ -274,7 +281,8 @@ export async function putShiftIfAbsent(
 				.filter((row) => row.opening_server_name === dedupe.openingServerName)
 				.first();
 			if (existing) return existing.offline_id;
-		} else if (dedupe.lifecycleId) {
+		}
+		if (dedupe.lifecycleId) {
 			const existing = await db.shifts.get(dedupe.lifecycleId);
 			if (existing) return existing.offline_id;
 		}

--- a/frontend/src/offline/repos/shifts.ts
+++ b/frontend/src/offline/repos/shifts.ts
@@ -20,7 +20,7 @@
  * table.
  */
 
-import { assertWritable, db } from "../db";
+import { assertWritable, db, runInTransaction } from "../db";
 import { decrypt, encrypt, getActiveKey } from "../crypto";
 import type {
 	EncryptedEnvelope,
@@ -207,6 +207,52 @@ export async function putShift(row: ShiftRow): Promise<void> {
 	assertWritable();
 	const stored = await toStored(row);
 	await db.shifts.put(stored);
+}
+
+/**
+ * Encrypt a candidate `ShiftRow` into its on-disk shape WITHOUT persisting
+ * it. Exported directly (not via `_internal`, which is documented as
+ * test/tooling-only) because `registerOpenedShift` (shift-lifecycle.ts)
+ * needs to encrypt a row BEFORE opening a Dexie transaction: `toStored`
+ * awaits `crypto.subtle`, a native, non-Dexie promise, and IndexedDB
+ * auto-commits a transaction the instant one of those is awaited inside
+ * its scope (PrematureCommitError — reproduced against this exact function
+ * in review). Encrypting up front and only conditionally `put`-ing inside
+ * `putShiftIfAbsent` keeps the transaction body 100% Dexie-native.
+ */
+export { toStored as buildStoredShift };
+
+/**
+ * Atomically register a PRE-ENCRYPTED stored row, deduping on either the
+ * server name or a caller-supplied durable id (`lifecycleId`) — without
+ * decrypting anything. `stored` must already be the output of
+ * `buildStoredShift`, produced OUTSIDE any transaction.
+ *
+ * Both dedupe checks compare plaintext scalars already present on
+ * `StoredShiftRow` (`opening_server_name`, the `offline_id` primary key),
+ * so the whole callback below is pure Dexie operations — `.filter().first()`,
+ * `.get()`, `.put()` — none of which is a non-Dexie promise, so the
+ * transaction can't prematurely commit the way a decrypt/encrypt call
+ * inside it would.
+ */
+export async function putShiftIfAbsent(
+	stored: StoredShiftRow,
+	dedupe: { openingServerName: string | null; lifecycleId?: string },
+): Promise<string> {
+	assertWritable();
+	return runInTransaction("rw", [db.shifts], async () => {
+		if (dedupe.openingServerName) {
+			const existing = await db.shifts
+				.filter((row) => row.opening_server_name === dedupe.openingServerName)
+				.first();
+			if (existing) return existing.offline_id;
+		} else if (dedupe.lifecycleId) {
+			const existing = await db.shifts.get(dedupe.lifecycleId);
+			if (existing) return existing.offline_id;
+		}
+		await db.shifts.put(stored);
+		return stored.offline_id;
+	});
 }
 
 /**

--- a/frontend/src/offline/repos/shifts.ts
+++ b/frontend/src/offline/repos/shifts.ts
@@ -199,6 +199,34 @@ export async function getShiftByOpeningServerName(
 	return fromStored(stored);
 }
 
+/**
+ * Plaintext scalars of every shift currently waiting on a queued closing.
+ *
+ * `pending_closing_offline_id`, `offline_id` and `status` are all plaintext
+ * on `StoredShiftRow`, so this deliberately skips `fromStored` — same
+ * reasoning as `getShiftByOpeningServerName` above: `listAllShifts()`
+ * decrypts every row in the table and throws the WHOLE lookup if any single
+ * unrelated row is corrupt or missing its opening-cash envelope. The two
+ * callers of this (startup reconciliation and closing-sync resolution) fail
+ * silently by design — a throw there would leave the app selling against a
+ * shift that is already closing, which is the exact bug this state exists
+ * to prevent — so they must not depend on the health of unrelated rows.
+ */
+export async function listPendingClosingShifts(): Promise<
+	Array<
+		Pick<StoredShiftRow, "offline_id" | "pending_closing_offline_id" | "status">
+	>
+> {
+	const stored = await db.shifts
+		.filter((row) => !!row.pending_closing_offline_id)
+		.toArray();
+	return stored.map((row) => ({
+		offline_id: row.offline_id,
+		pending_closing_offline_id: row.pending_closing_offline_id,
+		status: row.status,
+	}));
+}
+
 // ---------------------------------------------------------------------------
 // Write helpers
 // ---------------------------------------------------------------------------

--- a/frontend/src/offline/repos/shifts.ts
+++ b/frontend/src/offline/repos/shifts.ts
@@ -179,6 +179,26 @@ export async function listAllShifts(): Promise<ShiftRow[]> {
 	return Promise.all(stored.map(fromStored));
 }
 
+/**
+ * Look a shift up by its server doc name without decrypting the whole
+ * table. `opening_server_name` is a plaintext scalar on `StoredShiftRow`
+ * but is NOT part of the v1 Dexie index (`"offline_id, device_id,
+ * status"`), so this is a linear `.filter()`, not a `.where()` — still far
+ * cheaper than `listAllShifts()`, which does `Promise.all(rows.map(fromStored))`
+ * and both decrypts every row in the table on every call AND throws the
+ * whole lookup if any unrelated row is missing its opening-cash envelope
+ * (corruption). Here `fromStored` only ever runs on the single matched row.
+ */
+export async function getShiftByOpeningServerName(
+	serverName: string,
+): Promise<ShiftRow | undefined> {
+	const stored = await db.shifts
+		.filter((row) => row.opening_server_name === serverName)
+		.first();
+	if (!stored) return undefined;
+	return fromStored(stored);
+}
+
 // ---------------------------------------------------------------------------
 // Write helpers
 // ---------------------------------------------------------------------------

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -18,64 +18,101 @@
  * name exists, and the online-opened case is precisely the one that breaks.
  */
 
-import { getShiftById, listAllShifts, putShift } from "./repos/shifts";
+import { runInTransaction, db } from "./db";
+import {
+	getShiftById,
+	getShiftByOpeningServerName,
+	putShift,
+} from "./repos/shifts";
 import type { ShiftRow } from "./types";
 
 export interface OpenedShiftInput {
-	/** Server doc name, or null when the shift was opened offline. */
+	/**
+	 * Server doc name, or null when the shift has no confirmed server
+	 * identity yet. NOTE: this is NOT simply "shift opened offline" — a
+	 * synced offline shift keeps its (now permanent) `pos_offline_id`
+	 * server-side, so callers must key this off a sync-status flag
+	 * (e.g. `pospire_pending_sync`), not off `pos_offline_id`'s presence.
+	 */
 	openingServerName: string | null;
 	posProfile: Record<string, unknown>;
 	openingCashByMop: Record<string, number>;
 	cashierUser: string;
 	deviceId: string;
+	/**
+	 * Durable identity for a shift that has no server name yet (i.e. an
+	 * unsynced offline-opened shift) — its outbox `offline_id`
+	 * (`pos_offline_id` on the in-memory/provisional shift object).
+	 * Without this, every reload of an unsynced offline shift would
+	 * `crypto.randomUUID()` a brand-new row, breaking `getOpenShift()`'s
+	 * "at most one open shift per device" invariant. Leave undefined for
+	 * the online path, where `openingServerName` is the dedupe key.
+	 */
+	lifecycleId?: string;
 }
 
 /**
  * Record a newly opened shift and return its local lifecycle UUID.
  *
- * Idempotent on `openingServerName`: re-registering the same online-opened
- * shift (a reload, a second `check_opening_shift`) returns the existing UUID
- * rather than creating a duplicate row.
+ * Idempotent on `openingServerName` when present (online path / synced
+ * shift), otherwise on `lifecycleId` (unsynced offline path). Either way,
+ * re-registering an existing shift returns its EXISTING row's id unchanged
+ * — it never overwrites, since by the time of a re-registration Task 9's
+ * closing flow may already have advanced this row past `open`.
+ *
+ * The find-then-put is wrapped in a single `runInTransaction` because two
+ * `applyOpeningSnapshot` calls for the same shift (cached snapshot + live
+ * response) can race each other; without the transaction both could pass
+ * the "not found" check before either writes, producing two rows.
  */
 export async function registerOpenedShift(
 	input: OpenedShiftInput,
 ): Promise<string> {
-	if (input.openingServerName) {
-		const existing = await findShiftByServerName(input.openingServerName);
-		if (existing) return existing.offline_id;
-	}
+	return runInTransaction("rw", [db.shifts], async () => {
+		if (input.openingServerName) {
+			const existing = await findShiftByServerName(input.openingServerName);
+			if (existing) return existing.offline_id;
+		} else if (input.lifecycleId) {
+			const existing = await getShiftById(input.lifecycleId);
+			if (existing) return existing.offline_id;
+		}
 
-	const offlineId = crypto.randomUUID();
-	const row: ShiftRow = {
-		offline_id: offlineId,
-		device_id: input.deviceId,
-		cashier_user: input.cashierUser,
-		pos_profile: input.posProfile,
-		opening_cash_by_mop: input.openingCashByMop,
-		opened_at: Date.now(),
-		opening_server_name: input.openingServerName,
-		closing_cash_by_mop: null,
-		expected_closing_by_mop: null,
-		variance_at_close: null,
-		variance_at_sync: null,
-		closing_notes: null,
-		closed_at: null,
-		closing_server_name: null,
-		pending_closing_offline_id: null,
-		status: "open",
-		manager_approval_required: false,
-	};
-	await putShift(row);
-	return offlineId;
+		const offlineId = input.lifecycleId ?? crypto.randomUUID();
+		const row: ShiftRow = {
+			offline_id: offlineId,
+			device_id: input.deviceId,
+			cashier_user: input.cashierUser,
+			pos_profile: input.posProfile,
+			opening_cash_by_mop: input.openingCashByMop,
+			opened_at: Date.now(),
+			opening_server_name: input.openingServerName,
+			closing_cash_by_mop: null,
+			expected_closing_by_mop: null,
+			variance_at_close: null,
+			variance_at_sync: null,
+			closing_notes: null,
+			closed_at: null,
+			closing_server_name: null,
+			pending_closing_offline_id: null,
+			status: "open",
+			manager_approval_required: false,
+		};
+		await putShift(row);
+		return offlineId;
+	});
 }
 
-/** Look a shift up by its server doc name. Null-safe on unsynced shifts. */
+/**
+ * Look a shift up by its server doc name. Null-safe on unsynced shifts.
+ * Delegates to the repo's indexed-free `.filter()` lookup so a single
+ * corrupt row elsewhere in the table can't take down every registration
+ * attempt (as `listAllShifts()` + decrypt-all would).
+ */
 export async function findShiftByServerName(
 	serverName: string,
 ): Promise<ShiftRow | undefined> {
 	if (!serverName) return undefined;
-	const all = await listAllShifts();
-	return all.find((row) => row.opening_server_name === serverName);
+	return getShiftByOpeningServerName(serverName);
 }
 
 /** Re-export so callers never reach past this module into the repo. */

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -268,32 +268,73 @@ export interface QueuedPaymentSum {
  * netted of change. Change is NOT read from `inner.change_amount` — that
  * field is computed server-side, at submit time, by ERPNext's
  * `calculate_change_amount()` (erpnext/controllers/taxes_and_totals.py) and
- * does not exist on a queued-but-not-yet-submitted invoice payload. Instead
- * this reads `posa_submit_data.total_change`, the client-computed change
- * value `Payments.vue` already carries alongside the payment (see its
- * `submit_invoice()`: `total_change = !is_return ? -diff_payment : 0`), and
- * re-applies ERPNext's own guards before trusting it:
- *   - not a return (`calculate_change_amount`'s `not self.doc.is_return`);
- *   - a cash payment was actually tendered (mirrors
- *     `any(d.type == "Cash" for d in self.doc.payments)`). ERPNext's guard
- *     reads each payment row's `type`, fetched from the linked Mode of
- *     Payment (`Sales Invoice Payment.type`, `fetch_from:
- *     mode_of_payment.type`) — but that field is populated server-side at
- *     `.save()`/`.insert()` (see `posapp.py`'s `update_invoice`), so a queued
- *     invoice that never round-tripped through a server save while online
- *     (the exact case this stopgap exists for) never gets it written.
- *     Trusting `payments[].type` here would make the guard permanently
- *     false for genuinely offline invoices and defeat the fix it's meant to
- *     enable. Use the signal the rest of this codebase already relies on for
- *     the same purpose instead: `_aggregate_closing_from_invoices` nets
- *     change purely by `mode_of_payment == cash_mode`, with no `type` check
- *     at all — so "a cash-type payment was tendered" becomes "the profile's
- *     cash-mode row is present on this invoice with a positive amount";
- *   - the value is positive (mirrors `self.doc.paid_amount > grand_total`;
- *     a partial-payment invoice can have total_change negative and must not
- *     be "netted" into a bonus).
- * `parseInnerDoc`/`parseSubmitData` never throw on malformed JSON — a bad
- * payload just yields no change for that invoice, not an aborted scan.
+ * does not exist on a queued-but-not-yet-submitted invoice payload.
+ *
+ * It is also NOT read from `posa_submit_data.total_change` — an earlier
+ * revision of this function did, and that turned out to be an unreliable
+ * source with two measured failure modes, both reproduced against the real
+ * `submit_invoice` adapter:
+ *   1. `Payments.vue` computes `total_payments` (and therefore
+ *      `total_change`, via `diff_payment`) behind `if (!this.is_cashback)
+ *      total = 0`. On a POS Profile with `use_cashback = 0`, `is_cashback`
+ *      is false for every sale, so `total_change` comes out as
+ *      `-rounded_total`, gets clamped to 0 by the "positive" guard, and NO
+ *      change is ever netted for that entire class of profiles — the
+ *      original overstatement bug, fully restored.
+ *   2. `total_payments` also folds in `redeemed_customer_credit` and
+ *      `loyalty_amount`, neither of which the server's `paid_amount`
+ *      includes. An invoice with redeemed credit (e.g. grand_total 90,
+ *      credit 40, cash 60) nets a PHANTOM change the server never computes
+ *      (client sees "paid" 100 vs 90 -> change 10; server sees paid_amount
+ *      60 < 90 -> no change) and books cash short.
+ * Both failures share a root cause: `total_change` is a PARALLEL client-side
+ * calculation with its own gating and inputs that can drift from what the
+ * server actually books, rather than being derived from the same two
+ * numbers the server uses.
+ *
+ * Instead, this derives change exactly the way ERPNext does:
+ * `change = paid_amount - (rounded_total or grand_total)`, clamped to >= 0.
+ * `paid_amount` is summed directly from `payments[].amount` (mirrors
+ * ERPNext's own `calculate_paid_amount()`, not `posa_submit_data`), and
+ * `rounded_total` / `grand_total` are read straight off the inner doc.
+ * Both are reliably present on a genuinely-offline queued invoice —
+ * `Invoice.vue`'s `get_invoice_doc()` (lines ~2226-2241) stamps
+ * `rounded_total` equal to `grand_total` unconditionally, client-side, with
+ * no server round-trip required, even when the POS Profile disables
+ * rounding. The `rounded_total || grand_total` fallback (matching Python's
+ * `or`, where a falsy 0/absent value falls through) is kept anyway as a
+ * defensive match to the server's own condition, in case a future payload
+ * shape ever omits one.
+ *
+ * Guards applied, mirroring `calculate_change_amount`'s conditions:
+ *   - not a return (`not self.doc.is_return`) — see the `is_return` check
+ *     below; currently unreachable via the real adapter (which throws
+ *     `OfflineReturnDeferredError` for `is_return` before any invoice
+ *     payload is built — returns cannot reach the outbox as type `invoice`
+ *     in this phase), kept as defense-in-depth for a legacy row or future
+ *     offline-return support;
+ *   - the value is positive (`self.doc.paid_amount > grand_total`) — a
+ *     partial-payment invoice (`posa_allow_partial_payment`) can have
+ *     paid_amount < total; that must not "net" into a negative-turned-bonus.
+ *
+ * DELIBERATELY NOT mirrored: `any(d.type == "Cash" for d in payments)`.
+ * `type` (`Sales Invoice Payment.type`, fetch_from `mode_of_payment.type`)
+ * is populated server-side only when an invoice round-trips through
+ * `posapp.py`'s `update_invoice()` (`.save()`) while online — exactly the
+ * condition a genuinely offline invoice never meets — so it is unusable
+ * client-side. Two known, deliberate divergences follow from omitting it:
+ *   (1) a cash MOP whose underlying `Mode of Payment.type` is not "Cash":
+ *       the server's guard fails and nets nothing; this function still
+ *       nets the change.
+ *   (2) a zero-amount cash-mode payment row alongside over-tender on a
+ *       different MOP: the server nets the change against that (zero)
+ *       cash row and can drive its expected amount negative; this
+ *       function's per-invoice change is the same value, applied the same
+ *       way, so in the cases where the two arithmetically diverge the
+ *       client figure is arguably the physically correct one anyway — this
+ *       is exactly what the dialog's "provisional" label exists to cover.
+ * `parseInnerDoc` never throws on malformed JSON — a bad payload just
+ * yields no change for that invoice, not an aborted scan.
  *
  * This mirrors the server's CLOSING-time aggregation
  * (`_aggregate_closing_from_invoices` in pospire/pospire/api/offline.py),
@@ -394,7 +435,7 @@ export async function sumQueuedPaymentsByMop(input: {
 		}
 
 		const payments = (inner.payments as Array<Record<string, unknown>>) || [];
-		const change = resolveChangeAmount(inner, payments, input.cashMode);
+		const change = resolveChangeAmount(inner, payments);
 		for (const p of payments) {
 			const mop = String(p.mode_of_payment ?? "");
 			if (!mop) continue;
@@ -411,46 +452,44 @@ export async function sumQueuedPaymentsByMop(input: {
 }
 
 /**
- * Client-side stand-in for ERPNext's `calculate_change_amount()`. Reads the
- * change value `Payments.vue` already computed (`posa_submit_data.total_change`)
- * rather than `change_amount` (a server-only, post-submit field — see the
- * doc comment above `sumQueuedPaymentsByMop`), and applies the same three
- * guards the server checks before trusting it (see that doc comment for why
- * the "cash payment present" guard is checked via `cashMode` rather than
- * `payments[].type`). Returns 0 — meaning "net nothing" — whenever any guard
- * fails, exactly like the server leaving `change_amount` at its `0.0` default.
+ * Client-side stand-in for ERPNext's `calculate_change_amount()`. Derives
+ * change from `payments[].amount` and `rounded_total`/`grand_total` — the
+ * same two quantities the server computes it from — rather than from
+ * `posa_submit_data`, a parallel client calculation that measurably drifts
+ * from the server's numbers (see the doc comment above
+ * `sumQueuedPaymentsByMop` for the two reproduced failure modes, and for the
+ * `payments[].type` guard this deliberately does NOT attempt to mirror).
+ * Returns 0 — meaning "net nothing" — whenever a guard fails, exactly like
+ * the server leaving `change_amount` at its `0.0` default.
  */
 function resolveChangeAmount(
 	inner: Record<string, unknown>,
 	payments: Array<Record<string, unknown>>,
-	cashMode: string,
 ): number {
-	if (inner.is_return) return 0; // `not self.doc.is_return`
-	const cashPayment = payments.find(
-		(p) => String(p.mode_of_payment ?? "") === cashMode,
-	);
-	if (!cashPayment || !(Number(cashPayment.amount) > 0)) return 0; // `any(d.type == "Cash" ...)` proxy
-	const submitData = parseSubmitData(inner.posa_submit_data);
-	const totalChange = Number(submitData.total_change) || 0;
-	// `self.doc.paid_amount > grand_total` — a partial-payment invoice can
-	// have total_change negative; treat anything <= 0 as "no change given".
-	return totalChange > 0 ? totalChange : 0;
-}
+	// `not self.doc.is_return`. Currently unreachable via the real adapter,
+	// which throws `OfflineReturnDeferredError` for returns before any
+	// invoice payload is built (call-registry.ts) — kept as defense-in-depth
+	// so a future reader does not need to infer this from the adapter's
+	// behavior alone, and so it still holds if a legacy row or later offline-
+	// return support ever reaches this function.
+	if (inner.is_return) return 0;
 
-/**
- * Mirrors `Payments.vue`'s / `Invoice.vue`'s own `parseSubmitData` — the
- * wrapper stores `posa_submit_data` as either a JSON string or (for older
- * queued rows) an already-parsed object. Never throws.
- */
-function parseSubmitData(raw: unknown): Record<string, unknown> {
-	if (!raw) return {};
-	if (typeof raw === "object") return raw as Record<string, unknown>;
-	if (typeof raw !== "string") return {};
-	try {
-		return JSON.parse(raw) as Record<string, unknown>;
-	} catch {
-		return {};
-	}
+	const paidAmount = payments.reduce(
+		(sum, p) => sum + (Number(p.amount) || 0),
+		0,
+	);
+	// `self.doc.rounded_total or self.doc.grand_total`. Both fields are
+	// reliably present on the client's own queued doc — see the doc comment
+	// above `sumQueuedPaymentsByMop`. The `||` chain matches Python's `or`
+	// (a falsy 0/absent value falls through) rather than `??`, defensively,
+	// in case a differently-shaped payload ever omits `rounded_total`.
+	const total = Number(inner.rounded_total) || Number(inner.grand_total) || 0;
+
+	const change = paidAmount - total;
+	// `self.doc.paid_amount > grand_total` — a partial-payment invoice can
+	// have paid_amount < total; that must not "net" into a negative-turned-
+	// bonus.
+	return change > 0 ? change : 0;
 }
 
 function parseInnerDoc(payload: unknown): Record<string, unknown> | null {

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -292,19 +292,35 @@ export interface QueuedPaymentSum {
  * server actually books, rather than being derived from the same two
  * numbers the server uses.
  *
- * Instead, this derives change exactly the way ERPNext does:
- * `change = paid_amount - (rounded_total or grand_total)`, clamped to >= 0.
- * `paid_amount` is summed directly from `payments[].amount` (mirrors
- * ERPNext's own `calculate_paid_amount()`, not `posa_submit_data`), and
- * `rounded_total` / `grand_total` are read straight off the inner doc.
- * Both are reliably present on a genuinely-offline queued invoice —
+ * Instead, this derives change exactly the way ERPNext's
+ * `calculate_paid_amount()` + `calculate_change_amount()` do:
+ * `paid_amount = sum(payments[].amount) + (loyalty_amount / conversion_rate
+ * if redeem_loyalty_points else 0)`, `change = paid_amount - (rounded_total
+ * or grand_total)`, clamped to >= 0. The loyalty term matters: it is a real,
+ * measured divergence, not a hypothetical — a customer selected while
+ * online (so loyalty points/`conversion_factor` are known) followed by a
+ * connectivity drop before submit queues an invoice with
+ * `redeem_loyalty_points` + `loyalty_amount` stamped straight onto the doc
+ * by `Payments.vue`'s watcher, flowing through the adapter unchanged.
+ * Omitting it understated `paid_amount` and overstated cash by exactly the
+ * loyalty-funded change (grand_total 100, loyalty 30, cash 100: server nets
+ * change 30 and books 70; omitting loyalty here would book the full 100).
+ * `conversion_rate` is guarded against 0/missing (`|| 1`) so a bad or absent
+ * rate can't divide-by-zero into `NaN` and poison the whole aggregation —
+ * `Number(NaN)` is falsy, so a genuinely garbage `loyalty_amount` is also
+ * naturally skipped by the `redeem_loyalty_points && Number(loyalty_amount)`
+ * guard before it ever reaches a division.
+ *
+ * `rounded_total` / `grand_total` are read straight off the inner doc; both
+ * are reliably PRESENT on a genuinely-offline queued invoice —
  * `Invoice.vue`'s `get_invoice_doc()` (lines ~2226-2241) stamps
- * `rounded_total` equal to `grand_total` unconditionally, client-side, with
- * no server round-trip required, even when the POS Profile disables
- * rounding. The `rounded_total || grand_total` fallback (matching Python's
- * `or`, where a falsy 0/absent value falls through) is kept anyway as a
- * defensive match to the server's own condition, in case a future payload
- * shape ever omits one.
+ * `rounded_total` client-side with no server round-trip required. The
+ * `rounded_total || grand_total` fallback matches Python's `or` exactly
+ * (server's `set_rounded_total` sets `rounded_total = 0` outright when
+ * rounding is disabled, so the falls-through-to-grand_total behavior here is
+ * BY DESIGN, not a guess). What is NOT reproduced: `get_invoice_doc()`
+ * stamps `rounded_total = grand_total` VERBATIM, with no currency rounding
+ * applied — see the rounding divergence called out below.
  *
  * Guards applied, mirroring `calculate_change_amount`'s conditions:
  *   - not a return (`not self.doc.is_return`) — see the `is_return` check
@@ -322,17 +338,33 @@ export interface QueuedPaymentSum {
  * is populated server-side only when an invoice round-trips through
  * `posapp.py`'s `update_invoice()` (`.save()`) while online — exactly the
  * condition a genuinely offline invoice never meets — so it is unusable
- * client-side. Two known, deliberate divergences follow from omitting it:
+ * client-side.
+ *
+ * Known, deliberate divergences from the server that remain after the
+ * above (measured, not hypothetical — exhaustive as of this writing):
  *   (1) a cash MOP whose underlying `Mode of Payment.type` is not "Cash":
- *       the server's guard fails and nets nothing; this function still
- *       nets the change.
- *   (2) a zero-amount cash-mode payment row alongside over-tender on a
- *       different MOP: the server nets the change against that (zero)
- *       cash row and can drive its expected amount negative; this
- *       function's per-invoice change is the same value, applied the same
- *       way, so in the cases where the two arithmetically diverge the
- *       client figure is arguably the physically correct one anyway — this
- *       is exactly what the dialog's "provisional" label exists to cover.
+ *       the server's `any(type=="Cash")` guard fails and nets nothing;
+ *       this function still nets the change (since it doesn't check
+ *       `type` at all — see above).
+ *   (2) currency rounding: `get_invoice_doc()` never applies currency
+ *       rounding to `rounded_total`, but the server recomputes it on save
+ *       via `round_based_on_smallest_currency_fraction` — for currencies
+ *       with no smallest-fraction denomination (many do: INR, AED, SAR,
+ *       GBP, AUD — USD is a notable exception) this rounds to the nearest
+ *       whole unit. Example: grand_total 99.60, cash 100 -> this function
+ *       nets change 0.40 (books cash 99.60); the server sees
+ *       `rounded_total` snap to 100, `paid_amount(100) > 100` is false, no
+ *       change, books the full 100. Drift is bounded (well under 1 unit
+ *       per over-tendered cash sale) but accumulates across a shift's
+ *       invoices. Not something this stopgap can close without
+ *       reimplementing ERPNext's rounding table client-side — the client
+ *       figure is arguably the physically correct one anyway, which is
+ *       exactly what the dialog's "provisional" label exists to cover.
+ * (A zero-amount cash-mode row alongside over-tender elsewhere is NOT a
+ * divergence, despite an earlier revision of this comment claiming
+ * otherwise: that row still satisfies the server's `any(type=="Cash")`
+ * guard, so both sides net the same change against the same row and reach
+ * the same number.)
  * `parseInnerDoc` never throws on malformed JSON — a bad payload just
  * yields no change for that invoice, not an aborted scan.
  *
@@ -452,15 +484,17 @@ export async function sumQueuedPaymentsByMop(input: {
 }
 
 /**
- * Client-side stand-in for ERPNext's `calculate_change_amount()`. Derives
- * change from `payments[].amount` and `rounded_total`/`grand_total` — the
- * same two quantities the server computes it from — rather than from
- * `posa_submit_data`, a parallel client calculation that measurably drifts
- * from the server's numbers (see the doc comment above
- * `sumQueuedPaymentsByMop` for the two reproduced failure modes, and for the
- * `payments[].type` guard this deliberately does NOT attempt to mirror).
- * Returns 0 — meaning "net nothing" — whenever a guard fails, exactly like
- * the server leaving `change_amount` at its `0.0` default.
+ * Client-side stand-in for ERPNext's `calculate_paid_amount()` +
+ * `calculate_change_amount()`. Derives change from `payments[].amount`
+ * (plus loyalty redemption, converted the same way the server does) and
+ * `rounded_total`/`grand_total` — the same quantities the server computes it
+ * from — rather than from `posa_submit_data`, a parallel client calculation
+ * that measurably drifts from the server's numbers (see the doc comment
+ * above `sumQueuedPaymentsByMop` for the reproduced failure modes, the
+ * `payments[].type` guard this deliberately does NOT attempt to mirror, and
+ * the divergences that remain). Returns 0 — meaning "net nothing" —
+ * whenever a guard fails, exactly like the server leaving `change_amount`
+ * at its `0.0` default.
  */
 function resolveChangeAmount(
 	inner: Record<string, unknown>,
@@ -474,10 +508,25 @@ function resolveChangeAmount(
 	// return support ever reaches this function.
 	if (inner.is_return) return 0;
 
-	const paidAmount = payments.reduce(
+	let paidAmount = payments.reduce(
 		(sum, p) => sum + (Number(p.amount) || 0),
 		0,
 	);
+	// `if self.doc.redeem_loyalty_points and self.doc.loyalty_amount:
+	//      paid_amount += self.doc.loyalty_amount / flt(self.doc.conversion_rate)`
+	// (calculate_paid_amount, taxes_and_totals.py). Both fields are stamped
+	// straight onto invoice_doc by Payments.vue's loyalty_amount watcher and
+	// flow through the adapter unchanged — see the doc comment above
+	// sumQueuedPaymentsByMop for why this is a real, measured gap and not a
+	// defensive nicety. `Number(inner.loyalty_amount)` being falsy (0,
+	// missing, or NaN from a garbage value) short-circuits before any
+	// division, and `|| 1` on conversion_rate guards the division itself —
+	// a 0 or missing rate must not divide-by-zero into a NaN that would
+	// poison every payment in this invoice's contribution.
+	if (inner.redeem_loyalty_points && Number(inner.loyalty_amount)) {
+		const conversionRate = Number(inner.conversion_rate) || 1;
+		paidAmount += Number(inner.loyalty_amount) / conversionRate;
+	}
 	// `self.doc.rounded_total or self.doc.grand_total`. Both fields are
 	// reliably present on the client's own queued doc — see the doc comment
 	// above `sumQueuedPaymentsByMop`. The `||` chain matches Python's `or`

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -25,6 +25,7 @@ import {
 } from "./outbox";
 import {
 	buildStoredShift,
+	countShiftsByStatus,
 	getShiftById,
 	getShiftByOpeningServerName,
 	listPendingClosingShifts,
@@ -47,13 +48,20 @@ export interface OpenedShiftInput {
 	cashierUser: string;
 	deviceId: string;
 	/**
-	 * Durable identity for a shift that has no server name yet (i.e. an
-	 * unsynced offline-opened shift) — its outbox `offline_id`
-	 * (`pos_offline_id` on the in-memory/provisional shift object).
+	 * Durable identity of this shift's row: its outbox `offline_id`
+	 * (`pos_offline_id` on an unsynced offline-opened shift) or, once that
+	 * has been cleared by the sync handler, the `pospire_lifecycle_id`
+	 * stamped back onto the shift object / snapshot.
+	 *
 	 * Without this, every reload of an unsynced offline shift would
 	 * `crypto.randomUUID()` a brand-new row, breaking `getOpenShift()`'s
-	 * "at most one open shift per device" invariant. Leave undefined for
-	 * the online path, where `openingServerName` is the dedupe key.
+	 * "at most one open shift per device" invariant.
+	 *
+	 * Callers SHOULD pass it on the online path too, not just the offline
+	 * one: a shift opened offline and synced mid-shift arrives here with a
+	 * server name AND a lifecycle id, and the two dedupe keys are checked in
+	 * that order (see `putShiftIfAbsent`). Supplying both means the row is
+	 * still found even if `opening_server_name` never made it onto the row.
 	 */
 	lifecycleId?: string;
 }
@@ -61,11 +69,17 @@ export interface OpenedShiftInput {
 /**
  * Record a newly opened shift and return its local lifecycle UUID.
  *
- * Idempotent on `openingServerName` when present (online path / synced
- * shift), otherwise on `lifecycleId` (unsynced offline path). Either way,
- * re-registering an existing shift returns its EXISTING row's id unchanged
- * — it never overwrites, since by the time of a re-registration Task 9's
- * closing flow may already have advanced this row past `open`.
+ * Idempotent on `openingServerName` FIRST and then on `lifecycleId` — both
+ * are tried, never one or the other. A shift opened offline and synced
+ * mid-shift carries both keys but its row may still be keyed only by the
+ * lifecycle id (the row learns its server name from
+ * `attachOpeningServerName`, which is best-effort and can be missed if the
+ * tab is closed the instant the opening syncs). Checking a single key was
+ * enough to miss that row and create a SECOND `open` one, which silently
+ * dropped the closing-pending lock. Either way, re-registering an existing
+ * shift returns its EXISTING row's id unchanged — it never overwrites,
+ * since by the time of a re-registration Task 9's closing flow may already
+ * have advanced this row past `open`.
  *
  * The row is encrypted (`buildStoredShift`) BEFORE the transactional
  * dedupe-then-put (`putShiftIfAbsent`), never inside it. `crypto.subtle`
@@ -119,6 +133,45 @@ export async function findShiftByServerName(
 ): Promise<ShiftRow | undefined> {
 	if (!serverName) return undefined;
 	return getShiftByOpeningServerName(serverName);
+}
+
+/**
+ * Give an offline-opened shift its durable server identity, once its opening
+ * entry has synced.
+ *
+ * WHY THIS EXISTS: an offline-opened shift's row is created with
+ * `opening_server_name: null` and keyed only by its outbox id. When the
+ * opening syncs mid-shift, the sync handler clears `pos_offline_id` and
+ * `pospire_pending_sync` in memory and in the localStorage snapshot — so on
+ * the NEXT reload the shift presents itself as an ordinary server-named
+ * shift. Before this function existed, nothing ever wrote
+ * `opening_server_name` onto the row, so that reload's dedupe found nothing,
+ * created a SECOND `open` row, and the first row's `closed_pending_sync`
+ * lock silently stopped applying to the shift the cashier was actually on.
+ *
+ * The row's CURRENT status is preserved deliberately: by the time an opening
+ * syncs, the cashier may already have queued the close, and resetting a
+ * `closed_pending_sync` row to `open` here would unlock selling on a shift
+ * that is on its way out.
+ *
+ * Returns whether the row now carries the name. Refuses (returns false) when
+ * a DIFFERENT row already claims that server name rather than creating a
+ * duplicate claim — `getShiftByOpeningServerName` returns the first match,
+ * so two rows sharing a name would make the lookup non-deterministic.
+ */
+export async function attachOpeningServerName(
+	lifecycleId: string,
+	openingServerName: string,
+): Promise<boolean> {
+	if (!lifecycleId || !openingServerName) return false;
+	const claimed = await findShiftByServerName(openingServerName);
+	if (claimed) return claimed.offline_id === lifecycleId;
+	const row = await getShiftById(lifecycleId);
+	if (!row) return false;
+	await updateShiftStatus(lifecycleId, row.status, {
+		opening_server_name: openingServerName,
+	});
+	return true;
 }
 
 /** Re-export so callers never reach past this module into the repo. */
@@ -210,17 +263,27 @@ export async function isSellingBlocked(
  *
  * The outbox is the durable command log and therefore the reconciliation
  * source; `db.shifts` is what the running app reads. Any shift whose queued
- * closing has already left the unsynced set is RELEASED here — it landed (or
- * was voided) while the app was closed.
+ * closing has already left the unsynced set stops being closing-pending here
+ * — it landed, or was voided, while the app was closed. Those two outcomes
+ * are NOT the same and are reported separately below.
  *
- * Returns both halves. `released` is not bookkeeping: the caller must
+ * Returns three buckets. `released` is not bookkeeping: the caller must
  * invalidate any cached opening snapshot naming a released shift, or an
  * offline boot re-applies that snapshot and rings sales against a shift that
  * is closed server-side.
+ *
+ * `reopened` is the OPPOSITE case and must NOT be treated like `released`:
+ * a VOIDED closing means the shift was never closed at all — server-side it
+ * is still Open — so its snapshot has to survive and the row has to become
+ * usable again. Voiding a queued closing is an offered recovery action in
+ * the reconciliation workspace, and marking the shift terminal on a void
+ * turned that recovery into a trap: the cashier landed in the opening dialog
+ * and opened a SECOND shift against a first one that was never closed.
  */
 export async function reconcilePendingClosuresFromOutbox(): Promise<{
 	stillPending: string[];
 	released: string[];
+	reopened: string[];
 }> {
 	const closingStatusById = new Map(
 		(await listClosingEntryStatuses()).map((row) => [
@@ -231,6 +294,7 @@ export async function reconcilePendingClosuresFromOutbox(): Promise<{
 
 	const stillPending: string[] = [];
 	const released: string[] = [];
+	const reopened: string[] = [];
 	for (const row of await listPendingClosingShifts()) {
 		const pendingId = row.pending_closing_offline_id;
 		if (!pendingId) continue;
@@ -239,16 +303,36 @@ export async function reconcilePendingClosuresFromOutbox(): Promise<{
 			stillPending.push(row.offline_id);
 			continue;
 		}
+		if (closingStatus === "voided") {
+			// The close was withdrawn, so this shift is genuinely still open —
+			// drop the close timestamp along with the pending link.
+			//
+			// It only goes back to `open` when nothing else is: chained offline
+			// shifts are supported, so the cashier may already have opened a
+			// successor while this closing sat in the queue. Two `open` rows
+			// would break `getOpenShift()`'s "at most one open shift per device"
+			// invariant, so the older one lands in `needs_review` instead —
+			// honest (a human really does have two open shifts to sort out),
+			// non-terminal, and NOT `closed_pending_sync`, so it never blocks
+			// selling on the shift the cashier is actually using.
+			const anotherIsOpen = (await countShiftsByStatus("open")) > 0;
+			await updateShiftStatus(
+				row.offline_id,
+				anotherIsOpen ? "needs_review" : "open",
+				{ pending_closing_offline_id: null, closed_at: null },
+			);
+			reopened.push(row.offline_id);
+			continue;
+		}
+		// Synced, or an absent row (vacuumed tombstone) that tells us nothing
+		// either way — treated as landed, which is the safe direction: it stops
+		// the shift being sellable.
 		await updateShiftStatus(row.offline_id, "synced", {
 			pending_closing_offline_id: null,
-			// A voided closing means the shift was never closed at all, so it
-			// must not keep carrying a close timestamp. An absent row (vacuumed
-			// tombstone) tells us nothing either way, so leave `closed_at` be.
-			...(closingStatus === "voided" ? { closed_at: null } : {}),
 		});
 		released.push(row.offline_id);
 	}
-	return { stillPending, released };
+	return { stillPending, released, reopened };
 }
 
 // ---------------------------------------------------------------------------
@@ -450,12 +534,29 @@ export async function sumQueuedPaymentsByMop(input: {
 		if (row.status === "voided") continue;
 		if (seen.has(row.offline_id)) continue;
 
-		if (input.shiftOfflineId) {
-			if (row.shift_offline_id !== input.shiftOfflineId) continue;
-		} else {
-			if (row.shift_offline_id) continue;
-			if (readInnerShiftName(row.payload) !== input.openingServerName) continue;
-		}
+		// Both anchors are tried, never one or the other. A shift opened
+		// offline and synced MID-SHIFT has invoices on both sides of the
+		// sync: the earlier ones carry `shift_offline_id`, the later ones
+		// carry only the server name on the inner doc. The previous
+		// if/else picked the server-name branch as soon as
+		// `shiftOfflineId` was absent (which is exactly what the synced
+		// shift looks like, since the sync handler clears
+		// `pos_offline_id`) and skipped every row carrying a
+		// `shift_offline_id` — silently dropping the entire pre-sync half
+		// of the shift's takings from the expected amount.
+		//
+		// Neither clause can widen into another shift's money: the first
+		// demands an exact id match, and the second is gated on a non-null
+		// `openingServerName` so the `null === null` trap that the guard
+		// at the top of this function exists to prevent stays closed.
+		const matchesOfflineId =
+			!!input.shiftOfflineId &&
+			row.shift_offline_id === input.shiftOfflineId;
+		const matchesServerName =
+			!row.shift_offline_id &&
+			!!input.openingServerName &&
+			readInnerShiftName(row.payload) === input.openingServerName;
+		if (!matchesOfflineId && !matchesServerName) continue;
 
 		seen.add(row.offline_id);
 

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -18,7 +18,7 @@
  * name exists, and the online-opened case is precisely the one that breaks.
  */
 
-import { listByStatus } from "./outbox";
+import { listClosingEntryStatuses } from "./outbox";
 import {
 	buildStoredShift,
 	getShiftById,
@@ -125,13 +125,13 @@ export { getShiftById };
  * `synced` and `voided` are both terminal and both mean the closing is no
  * longer in flight, so neither keeps a shift locked.
  */
-const UNSYNCED_OUTBOX_STATUSES: readonly OutboxStatus[] = [
+const UNSYNCED_OUTBOX_STATUSES: ReadonlySet<OutboxStatus> = new Set([
 	"enqueued",
 	"in_flight",
 	"retry_pending",
 	"needs_review",
 	"handed_off",
-];
+]);
 
 /**
  * Mark a shift as closing-pending against a queued closing entry.
@@ -161,6 +161,7 @@ export async function markShiftClosingPending(
  */
 export async function resolveClosingSynced(
 	closingOfflineId: string,
+	closingServerName: string | null = null,
 ): Promise<{ shiftLifecycleId: string; wasActive: boolean } | null> {
 	if (!closingOfflineId) return null;
 	const pending = await listPendingClosingShifts();
@@ -171,6 +172,10 @@ export async function resolveClosingSynced(
 
 	await updateShiftStatus(match.offline_id, "synced", {
 		pending_closing_offline_id: null,
+		// The server's name for the closing doc. The row would otherwise never
+		// learn it — this is the only moment it exists AND we know which shift
+		// it belongs to.
+		closing_server_name: closingServerName,
 	});
 	return {
 		shiftLifecycleId: match.offline_id,
@@ -201,32 +206,43 @@ export async function isSellingBlocked(
  *
  * The outbox is the durable command log and therefore the reconciliation
  * source; `db.shifts` is what the running app reads. Any shift whose queued
- * closing has already left the unsynced set is released here — it landed
- * (or was voided) while the app was closed.
+ * closing has already left the unsynced set is RELEASED here — it landed (or
+ * was voided) while the app was closed.
  *
- * Returns the lifecycle ids that are still legitimately closing-pending.
+ * Returns both halves. `released` is not bookkeeping: the caller must
+ * invalidate any cached opening snapshot naming a released shift, or an
+ * offline boot re-applies that snapshot and rings sales against a shift that
+ * is closed server-side.
  */
-export async function reconcilePendingClosuresFromOutbox(): Promise<string[]> {
-	const unsynced = (
-		await Promise.all(UNSYNCED_OUTBOX_STATUSES.map((s) => listByStatus(s)))
-	).flat();
-	const liveClosingIds = new Set(
-		unsynced
-			.filter((row) => row.type === "closing_entry")
-			.map((row) => row.offline_id),
+export async function reconcilePendingClosuresFromOutbox(): Promise<{
+	stillPending: string[];
+	released: string[];
+}> {
+	const closingStatusById = new Map(
+		(await listClosingEntryStatuses()).map((row) => [
+			row.offline_id,
+			row.status,
+		]),
 	);
 
 	const stillPending: string[] = [];
+	const released: string[] = [];
 	for (const row of await listPendingClosingShifts()) {
 		const pendingId = row.pending_closing_offline_id;
 		if (!pendingId) continue;
-		if (liveClosingIds.has(pendingId)) {
+		const closingStatus = closingStatusById.get(pendingId);
+		if (closingStatus && UNSYNCED_OUTBOX_STATUSES.has(closingStatus)) {
 			stillPending.push(row.offline_id);
-		} else {
-			await updateShiftStatus(row.offline_id, "synced", {
-				pending_closing_offline_id: null,
-			});
+			continue;
 		}
+		await updateShiftStatus(row.offline_id, "synced", {
+			pending_closing_offline_id: null,
+			// A voided closing means the shift was never closed at all, so it
+			// must not keep carrying a close timestamp. An absent row (vacuumed
+			// tombstone) tells us nothing either way, so leave `closed_at` be.
+			...(closingStatus === "voided" ? { closed_at: null } : {}),
+		});
+		released.push(row.offline_id);
 	}
-	return stillPending;
+	return { stillPending, released };
 }

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -1,0 +1,82 @@
+/**
+ * Shift lifecycle authority.
+ *
+ * `db.shifts` is the durable answer to "which shift is active, which shifts
+ * are closing, and is selling allowed right now". The outbox remains the
+ * durable command / audit log and the source for startup reconciliation —
+ * the two are not competing stores: one holds state, the other holds intent.
+ *
+ * Before this module, all three of those facts lived in Vue component memory
+ * plus a single-slot `localStorage` snapshot that the close path nulled out.
+ * A single slot cannot represent "shift A is closing-pending" and "shift B is
+ * active" at the same time, which is the normal state right after an offline
+ * close — the cashier is routed to the opening dialog and may open B while
+ * A's closing waits to sync.
+ *
+ * Every shift gets a local lifecycle UUID on open, INCLUDING shifts opened
+ * online. Without it there is no stable key to hang state on before a server
+ * name exists, and the online-opened case is precisely the one that breaks.
+ */
+
+import { getShiftById, listAllShifts, putShift } from "./repos/shifts";
+import type { ShiftRow } from "./types";
+
+export interface OpenedShiftInput {
+	/** Server doc name, or null when the shift was opened offline. */
+	openingServerName: string | null;
+	posProfile: Record<string, unknown>;
+	openingCashByMop: Record<string, number>;
+	cashierUser: string;
+	deviceId: string;
+}
+
+/**
+ * Record a newly opened shift and return its local lifecycle UUID.
+ *
+ * Idempotent on `openingServerName`: re-registering the same online-opened
+ * shift (a reload, a second `check_opening_shift`) returns the existing UUID
+ * rather than creating a duplicate row.
+ */
+export async function registerOpenedShift(
+	input: OpenedShiftInput,
+): Promise<string> {
+	if (input.openingServerName) {
+		const existing = await findShiftByServerName(input.openingServerName);
+		if (existing) return existing.offline_id;
+	}
+
+	const offlineId = crypto.randomUUID();
+	const row: ShiftRow = {
+		offline_id: offlineId,
+		device_id: input.deviceId,
+		cashier_user: input.cashierUser,
+		pos_profile: input.posProfile,
+		opening_cash_by_mop: input.openingCashByMop,
+		opened_at: Date.now(),
+		opening_server_name: input.openingServerName,
+		closing_cash_by_mop: null,
+		expected_closing_by_mop: null,
+		variance_at_close: null,
+		variance_at_sync: null,
+		closing_notes: null,
+		closed_at: null,
+		closing_server_name: null,
+		pending_closing_offline_id: null,
+		status: "open",
+		manager_approval_required: false,
+	};
+	await putShift(row);
+	return offlineId;
+}
+
+/** Look a shift up by its server doc name. Null-safe on unsynced shifts. */
+export async function findShiftByServerName(
+	serverName: string,
+): Promise<ShiftRow | undefined> {
+	if (!serverName) return undefined;
+	const all = await listAllShifts();
+	return all.find((row) => row.opening_server_name === serverName);
+}
+
+/** Re-export so callers never reach past this module into the repo. */
+export { getShiftById };

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -18,11 +18,11 @@
  * name exists, and the online-opened case is precisely the one that breaks.
  */
 
-import { runInTransaction, db } from "./db";
 import {
+	buildStoredShift,
 	getShiftById,
 	getShiftByOpeningServerName,
-	putShift,
+	putShiftIfAbsent,
 } from "./repos/shifts";
 import type { ShiftRow } from "./types";
 
@@ -60,45 +60,44 @@ export interface OpenedShiftInput {
  * — it never overwrites, since by the time of a re-registration Task 9's
  * closing flow may already have advanced this row past `open`.
  *
- * The find-then-put is wrapped in a single `runInTransaction` because two
- * `applyOpeningSnapshot` calls for the same shift (cached snapshot + live
- * response) can race each other; without the transaction both could pass
- * the "not found" check before either writes, producing two rows.
+ * The row is encrypted (`buildStoredShift`) BEFORE the transactional
+ * dedupe-then-put (`putShiftIfAbsent`), never inside it. `crypto.subtle`
+ * returns native, non-Dexie promises; awaiting one inside a Dexie
+ * transaction's callback lets IndexedDB auto-commit the transaction out
+ * from under it (`PrematureCommitError`), which silently defeats both the
+ * dedupe check AND the write on every single call — this was tried in an
+ * earlier revision and reproduced against this exact function in review.
+ * Encrypting a row that turns out to be a duplicate (the dedupe-hit path)
+ * is wasted work, but that's a rare path and a cheap price for the
+ * transaction actually working.
  */
 export async function registerOpenedShift(
 	input: OpenedShiftInput,
 ): Promise<string> {
-	return runInTransaction("rw", [db.shifts], async () => {
-		if (input.openingServerName) {
-			const existing = await findShiftByServerName(input.openingServerName);
-			if (existing) return existing.offline_id;
-		} else if (input.lifecycleId) {
-			const existing = await getShiftById(input.lifecycleId);
-			if (existing) return existing.offline_id;
-		}
-
-		const offlineId = input.lifecycleId ?? crypto.randomUUID();
-		const row: ShiftRow = {
-			offline_id: offlineId,
-			device_id: input.deviceId,
-			cashier_user: input.cashierUser,
-			pos_profile: input.posProfile,
-			opening_cash_by_mop: input.openingCashByMop,
-			opened_at: Date.now(),
-			opening_server_name: input.openingServerName,
-			closing_cash_by_mop: null,
-			expected_closing_by_mop: null,
-			variance_at_close: null,
-			variance_at_sync: null,
-			closing_notes: null,
-			closed_at: null,
-			closing_server_name: null,
-			pending_closing_offline_id: null,
-			status: "open",
-			manager_approval_required: false,
-		};
-		await putShift(row);
-		return offlineId;
+	const offlineId = input.lifecycleId ?? crypto.randomUUID();
+	const row: ShiftRow = {
+		offline_id: offlineId,
+		device_id: input.deviceId,
+		cashier_user: input.cashierUser,
+		pos_profile: input.posProfile,
+		opening_cash_by_mop: input.openingCashByMop,
+		opened_at: Date.now(),
+		opening_server_name: input.openingServerName,
+		closing_cash_by_mop: null,
+		expected_closing_by_mop: null,
+		variance_at_close: null,
+		variance_at_sync: null,
+		closing_notes: null,
+		closed_at: null,
+		closing_server_name: null,
+		pending_closing_offline_id: null,
+		status: "open",
+		manager_approval_required: false,
+	};
+	const stored = await buildStoredShift(row);
+	return putShiftIfAbsent(stored, {
+		openingServerName: input.openingServerName,
+		lifecycleId: input.lifecycleId,
 	});
 }
 

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -18,7 +18,11 @@
  * name exists, and the online-opened case is precisely the one that breaks.
  */
 
-import { listClosingEntryStatuses } from "./outbox";
+import {
+	listClosingEntryStatuses,
+	listInvoiceRowsAcrossStatuses,
+	readInnerShiftName,
+} from "./outbox";
 import {
 	buildStoredShift,
 	getShiftById,
@@ -245,4 +249,119 @@ export async function reconcilePendingClosuresFromOutbox(): Promise<{
 		released.push(row.offline_id);
 	}
 	return { stillPending, released };
+}
+
+// ---------------------------------------------------------------------------
+// Task 10 — stopgap expected-amount aggregation for the offline close dialog
+// ---------------------------------------------------------------------------
+
+export interface QueuedPaymentSum {
+	byMop: Record<string, number>;
+	/** Invoices in needs_review / handed_off — included, but flagged. */
+	uncertainCount: number;
+}
+
+/**
+ * Sum queued invoice payments for a shift, by mode of payment.
+ *
+ * Mirrors the server aggregation (`_aggregate_closing_from_invoices`) so the
+ * cashier reconciles against the same arithmetic the synced record will use:
+ * cash net of change, every other MOP at face value, site precision applied
+ * before summing. Diverging here would show one number at close time and a
+ * different one on the saved record.
+ *
+ * needs_review / handed_off invoices ARE included: the figure estimates what
+ * the cashier physically holds, and that money was taken whether or not the
+ * record reached the server. Excluding it would manufacture a false shortfall.
+ * The count is returned so the UI can say how much of the total is unconfirmed.
+ *
+ * This is a STOPGAP for offline-queued sales only (Issue 3, Task 10). Sales
+ * made earlier in the shift while online leave no trace in the outbox and are
+ * NOT recovered here — that needs the Phase 2 per-invoice contribution
+ * ledger. Callers must label whatever they build from this figure provisional.
+ */
+export async function sumQueuedPaymentsByMop(input: {
+	openingServerName: string | null;
+	shiftOfflineId: string | null;
+	cashMode: string;
+	precision: number;
+}): Promise<QueuedPaymentSum> {
+	const buckets: OutboxStatus[] = [
+		"enqueued",
+		"in_flight",
+		"retry_pending",
+		"needs_review",
+		"handed_off",
+		"synced",
+	];
+	// Uses the corrupt-row-resilient scan rather than composing `listByStatus`
+	// calls: `listByStatus` decrypts every row in a bucket via a single
+	// `Promise.all` and rejects the WHOLE bucket if any one row fails to
+	// decrypt. Composed across six buckets under this function's own
+	// aggregation, a single poison invoice anywhere would throw all the way
+	// out to Pos.vue's try/catch and silently zero the cashier's entire
+	// expected-amount figure — not just the bad invoice's share of it.
+	const { rows, corruptCount } = await listInvoiceRowsAcrossStatuses(buckets);
+	if (corruptCount > 0) {
+		// Not surfaced to the cashier (would require widening the return
+		// shape and the dialog's UI beyond this stopgap's scope) but must not
+		// vanish silently either — this is the one signal an operator has
+		// that the total is short by an unknown, undecryptable invoice.
+		console.warn(
+			`[shift-lifecycle] sumQueuedPaymentsByMop: skipped ${corruptCount} outbox row(s) that failed to decrypt`,
+		);
+	}
+
+	const seen = new Set<string>();
+	const byMop: Record<string, number> = {};
+	let uncertainCount = 0;
+
+	for (const row of rows) {
+		if (row.status === "voided") continue;
+		if (seen.has(row.offline_id)) continue;
+
+		if (input.shiftOfflineId) {
+			if (row.shift_offline_id !== input.shiftOfflineId) continue;
+		} else {
+			if (row.shift_offline_id) continue;
+			if (readInnerShiftName(row.payload) !== input.openingServerName) continue;
+		}
+
+		seen.add(row.offline_id);
+		if (row.status === "needs_review" || row.status === "handed_off") {
+			uncertainCount += 1;
+		}
+
+		const inner = parseInnerDoc(row.payload);
+		if (!inner) continue;
+		const change = Number(inner.change_amount) || 0;
+		for (const p of (inner.payments as Array<Record<string, unknown>>) || []) {
+			const mop = String(p.mode_of_payment ?? "");
+			if (!mop) continue;
+			const raw = Number(p.amount) || 0;
+			const net = mop === input.cashMode ? raw - change : raw;
+			byMop[mop] = round(
+				(byMop[mop] ?? 0) + round(net, input.precision),
+				input.precision,
+			);
+		}
+	}
+
+	return { byMop, uncertainCount };
+}
+
+function parseInnerDoc(payload: unknown): Record<string, unknown> | null {
+	if (!payload || typeof payload !== "object") return null;
+	const p = payload as Record<string, unknown>;
+	if (typeof p.data !== "string") return p;
+	try {
+		return JSON.parse(p.data) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function round(value: number, precision: number): number {
+	const f = 10 ** precision;
+	return Math.round(value * f) / f;
 }

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -264,16 +264,64 @@ export interface QueuedPaymentSum {
 /**
  * Sum queued invoice payments for a shift, by mode of payment.
  *
- * Mirrors the server aggregation (`_aggregate_closing_from_invoices`) so the
- * cashier reconciles against the same arithmetic the synced record will use:
- * cash net of change, every other MOP at face value, site precision applied
- * before summing. Diverging here would show one number at close time and a
- * different one on the saved record.
+ * Every MOP is summed at face value EXCEPT the profile's cash MOP, which is
+ * netted of change. Change is NOT read from `inner.change_amount` — that
+ * field is computed server-side, at submit time, by ERPNext's
+ * `calculate_change_amount()` (erpnext/controllers/taxes_and_totals.py) and
+ * does not exist on a queued-but-not-yet-submitted invoice payload. Instead
+ * this reads `posa_submit_data.total_change`, the client-computed change
+ * value `Payments.vue` already carries alongside the payment (see its
+ * `submit_invoice()`: `total_change = !is_return ? -diff_payment : 0`), and
+ * re-applies ERPNext's own guards before trusting it:
+ *   - not a return (`calculate_change_amount`'s `not self.doc.is_return`);
+ *   - a cash payment was actually tendered (mirrors
+ *     `any(d.type == "Cash" for d in self.doc.payments)`). ERPNext's guard
+ *     reads each payment row's `type`, fetched from the linked Mode of
+ *     Payment (`Sales Invoice Payment.type`, `fetch_from:
+ *     mode_of_payment.type`) — but that field is populated server-side at
+ *     `.save()`/`.insert()` (see `posapp.py`'s `update_invoice`), so a queued
+ *     invoice that never round-tripped through a server save while online
+ *     (the exact case this stopgap exists for) never gets it written.
+ *     Trusting `payments[].type` here would make the guard permanently
+ *     false for genuinely offline invoices and defeat the fix it's meant to
+ *     enable. Use the signal the rest of this codebase already relies on for
+ *     the same purpose instead: `_aggregate_closing_from_invoices` nets
+ *     change purely by `mode_of_payment == cash_mode`, with no `type` check
+ *     at all — so "a cash-type payment was tendered" becomes "the profile's
+ *     cash-mode row is present on this invoice with a positive amount";
+ *   - the value is positive (mirrors `self.doc.paid_amount > grand_total`;
+ *     a partial-payment invoice can have total_change negative and must not
+ *     be "netted" into a bonus).
+ * `parseInnerDoc`/`parseSubmitData` never throw on malformed JSON — a bad
+ * payload just yields no change for that invoice, not an aborted scan.
+ *
+ * This mirrors the server's CLOSING-time aggregation
+ * (`_aggregate_closing_from_invoices` in pospire/pospire/api/offline.py),
+ * NOT the live opening-to-closing builder — the live builder has a quirk
+ * where the first invoice of a MOP absent from `balance_details` never nets
+ * change, which `_aggregate_closing_from_invoices` (and this function) does
+ * not reproduce. Diverging from `_aggregate_closing_from_invoices` here
+ * would show one number at close time and a different one on the record
+ * that eventually syncs.
+ *
+ * One deliberate divergence: the server's summation (`pay_expected[...] +=
+ * amount`, a bare `flt` add with no intermediate rounding) applies NO
+ * rounding until the field is saved. This function rounds each net payment
+ * to `input.precision` before accumulating, and rounds the running total
+ * again after each add. That is NOT the server's algorithm — it is a
+ * defensive per-payment clamp so a queued payload with excess float noise
+ * (e.g. `19.999999999998`) can't drift the display. At 2 decimal places (or
+ * whatever `precision` the caller passes — see the site's
+ * `currency_precision`, not a hardcoded constant) the difference against the
+ * server's unrounded-until-save total is not observable in practice, but a
+ * currency with unusual rounding behavior could show a hairline discrepancy.
  *
  * needs_review / handed_off invoices ARE included: the figure estimates what
  * the cashier physically holds, and that money was taken whether or not the
  * record reached the server. Excluding it would manufacture a false shortfall.
  * The count is returned so the UI can say how much of the total is unconfirmed.
+ * Invoices whose inner doc fails to parse are NOT counted here — they contribute
+ * no money and are a distinct failure mode (unreadable, not merely unconfirmed).
  *
  * This is a STOPGAP for offline-queued sales only (Issue 3, Task 10). Sales
  * made earlier in the shift while online leave no trace in the outbox and are
@@ -286,6 +334,15 @@ export async function sumQueuedPaymentsByMop(input: {
 	cashMode: string;
 	precision: number;
 }): Promise<QueuedPaymentSum> {
+	// Without an anchor, `row.shift_offline_id` falsy AND
+	// `readInnerShiftName(row.payload) === null` would match EVERY unanchored
+	// invoice in the outbox — including other shifts' — because `null ===
+	// null`. Refuse to aggregate rather than silently pull in other shifts'
+	// money.
+	if (!input.shiftOfflineId && !input.openingServerName) {
+		return { byMop: {}, uncertainCount: 0 };
+	}
+
 	const buckets: OutboxStatus[] = [
 		"enqueued",
 		"in_flight",
@@ -328,14 +385,17 @@ export async function sumQueuedPaymentsByMop(input: {
 		}
 
 		seen.add(row.offline_id);
+
+		const inner = parseInnerDoc(row.payload);
+		if (!inner) continue; // unparseable: contributes nothing, not "uncertain" money — see doc comment.
+
 		if (row.status === "needs_review" || row.status === "handed_off") {
 			uncertainCount += 1;
 		}
 
-		const inner = parseInnerDoc(row.payload);
-		if (!inner) continue;
-		const change = Number(inner.change_amount) || 0;
-		for (const p of (inner.payments as Array<Record<string, unknown>>) || []) {
+		const payments = (inner.payments as Array<Record<string, unknown>>) || [];
+		const change = resolveChangeAmount(inner, payments, input.cashMode);
+		for (const p of payments) {
 			const mop = String(p.mode_of_payment ?? "");
 			if (!mop) continue;
 			const raw = Number(p.amount) || 0;
@@ -348,6 +408,49 @@ export async function sumQueuedPaymentsByMop(input: {
 	}
 
 	return { byMop, uncertainCount };
+}
+
+/**
+ * Client-side stand-in for ERPNext's `calculate_change_amount()`. Reads the
+ * change value `Payments.vue` already computed (`posa_submit_data.total_change`)
+ * rather than `change_amount` (a server-only, post-submit field — see the
+ * doc comment above `sumQueuedPaymentsByMop`), and applies the same three
+ * guards the server checks before trusting it (see that doc comment for why
+ * the "cash payment present" guard is checked via `cashMode` rather than
+ * `payments[].type`). Returns 0 — meaning "net nothing" — whenever any guard
+ * fails, exactly like the server leaving `change_amount` at its `0.0` default.
+ */
+function resolveChangeAmount(
+	inner: Record<string, unknown>,
+	payments: Array<Record<string, unknown>>,
+	cashMode: string,
+): number {
+	if (inner.is_return) return 0; // `not self.doc.is_return`
+	const cashPayment = payments.find(
+		(p) => String(p.mode_of_payment ?? "") === cashMode,
+	);
+	if (!cashPayment || !(Number(cashPayment.amount) > 0)) return 0; // `any(d.type == "Cash" ...)` proxy
+	const submitData = parseSubmitData(inner.posa_submit_data);
+	const totalChange = Number(submitData.total_change) || 0;
+	// `self.doc.paid_amount > grand_total` — a partial-payment invoice can
+	// have total_change negative; treat anything <= 0 as "no change given".
+	return totalChange > 0 ? totalChange : 0;
+}
+
+/**
+ * Mirrors `Payments.vue`'s / `Invoice.vue`'s own `parseSubmitData` — the
+ * wrapper stores `posa_submit_data` as either a JSON string or (for older
+ * queued rows) an already-parsed object. Never throws.
+ */
+function parseSubmitData(raw: unknown): Record<string, unknown> {
+	if (!raw) return {};
+	if (typeof raw === "object") return raw as Record<string, unknown>;
+	if (typeof raw !== "string") return {};
+	try {
+		return JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		return {};
+	}
 }
 
 function parseInnerDoc(payload: unknown): Record<string, unknown> | null {

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -18,13 +18,16 @@
  * name exists, and the online-opened case is precisely the one that breaks.
  */
 
+import { listByStatus } from "./outbox";
 import {
 	buildStoredShift,
 	getShiftById,
 	getShiftByOpeningServerName,
+	listPendingClosingShifts,
 	putShiftIfAbsent,
+	updateShiftStatus,
 } from "./repos/shifts";
-import type { ShiftRow } from "./types";
+import type { OutboxStatus, ShiftRow } from "./types";
 
 export interface OpenedShiftInput {
 	/**
@@ -116,3 +119,114 @@ export async function findShiftByServerName(
 
 /** Re-export so callers never reach past this module into the repo. */
 export { getShiftById };
+
+/**
+ * Outbox statuses that mean "this command has NOT landed on the server yet".
+ * `synced` and `voided` are both terminal and both mean the closing is no
+ * longer in flight, so neither keeps a shift locked.
+ */
+const UNSYNCED_OUTBOX_STATUSES: readonly OutboxStatus[] = [
+	"enqueued",
+	"in_flight",
+	"retry_pending",
+	"needs_review",
+	"handed_off",
+];
+
+/**
+ * Mark a shift as closing-pending against a queued closing entry.
+ *
+ * The link is `pending_closing_offline_id` — the closing's own outbox id —
+ * and NOT `closing_server_name`, which does not exist until the closing has
+ * actually synced.
+ */
+export async function markShiftClosingPending(
+	shiftLifecycleId: string,
+	closingOfflineId: string,
+): Promise<void> {
+	await updateShiftStatus(shiftLifecycleId, "closed_pending_sync", {
+		closed_at: Date.now(),
+		pending_closing_offline_id: closingOfflineId,
+	});
+}
+
+/**
+ * Resolve a synced closing back to its shift.
+ *
+ * Keys off the CLOSING's own offline_id, never off whatever shift happens to
+ * be active — reading the active shift's marker is what let a synced closing
+ * for shift A reset shift B, and what made the handler silently no-op after
+ * a reload. Returns null when no shift is waiting on this closing, so an
+ * unknown id changes nothing.
+ */
+export async function resolveClosingSynced(
+	closingOfflineId: string,
+): Promise<{ shiftLifecycleId: string; wasActive: boolean } | null> {
+	if (!closingOfflineId) return null;
+	const pending = await listPendingClosingShifts();
+	const match = pending.find(
+		(row) => row.pending_closing_offline_id === closingOfflineId,
+	);
+	if (!match) return null;
+
+	await updateShiftStatus(match.offline_id, "synced", {
+		pending_closing_offline_id: null,
+	});
+	return {
+		shiftLifecycleId: match.offline_id,
+		// The shift was still awaiting its close (rather than already
+		// advanced past it by a reconciliation pass) when this landed.
+		wasActive: match.status === "closed_pending_sync",
+	};
+}
+
+/**
+ * Is selling blocked right now?
+ *
+ * Blocked ONLY when the shift the cashier is actively on is itself closing.
+ * A closing-pending shift A must not lock selling on a freshly opened B —
+ * chained offline shifts are a supported requirement, and blocking them
+ * would halt sales during exactly the outage offline mode exists for.
+ */
+export async function isSellingBlocked(
+	activeShiftLifecycleId: string | null,
+): Promise<boolean> {
+	if (!activeShiftLifecycleId) return false;
+	const row = await getShiftById(activeShiftLifecycleId);
+	return row?.status === "closed_pending_sync";
+}
+
+/**
+ * Rebuild closing-pending state from the outbox after a reload.
+ *
+ * The outbox is the durable command log and therefore the reconciliation
+ * source; `db.shifts` is what the running app reads. Any shift whose queued
+ * closing has already left the unsynced set is released here — it landed
+ * (or was voided) while the app was closed.
+ *
+ * Returns the lifecycle ids that are still legitimately closing-pending.
+ */
+export async function reconcilePendingClosuresFromOutbox(): Promise<string[]> {
+	const unsynced = (
+		await Promise.all(UNSYNCED_OUTBOX_STATUSES.map((s) => listByStatus(s)))
+	).flat();
+	const liveClosingIds = new Set(
+		unsynced
+			.filter((row) => row.type === "closing_entry")
+			.map((row) => row.offline_id),
+	);
+
+	const stillPending: string[] = [];
+	for (const row of await listPendingClosingShifts()) {
+		const pendingId = row.pending_closing_offline_id;
+		if (!pendingId) continue;
+		if (liveClosingIds.has(pendingId)) {
+			stillPending.push(row.offline_id);
+		} else {
+			await updateShiftStatus(row.offline_id, "synced", {
+				pending_closing_offline_id: null,
+			});
+		}
+	}
+	return stillPending;
+}

--- a/frontend/src/offline/sync.ts
+++ b/frontend/src/offline/sync.ts
@@ -89,6 +89,8 @@ export interface SyncCycleLog {
 	longest_latency_ms: number;
 	next_wake_ms: number | null;
 	leader: boolean;
+	/** Rows parked on a dependency 409 (siblings/parent not ready) this cycle. */
+	parked?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -635,6 +637,9 @@ export class SyncScheduler {
 						result.category,
 						result.detail,
 					);
+				} else if (result.kind === "park") {
+					await markBlocked(entry.offline_id, result.reason);
+					cycle.parked = (cycle.parked ?? 0) + 1;
 				} else {
 					// Mark needs_review first (stable terminal state) before attempting
 					// handoff — the next cycle retries the handoff if it fails.
@@ -963,6 +968,12 @@ type SendResult =
 			kind: "needsReview";
 			category: NonNullable<LastErrorCategory>;
 			detail: string | null;
+	  }
+	| {
+			kind: "park";
+			reason: "waiting_for_parent" | "waiting_for_siblings";
+			detail: string;
+			missingOfflineIds: string[];
 	  };
 
 // ---------------------------------------------------------------------------
@@ -1454,17 +1465,35 @@ function classifySendError(
 			};
 		}
 		if (status === 409) {
-			// 409 is the dependency / conflict bucket on the server:
-			// parent_not_ready, siblings_not_ready, stock_shortage, batch_or_
-			// serial_conflict. The previous default (batch_or_serial_conflict)
-			// collapsed unrelated failures into the wrong fix flow. When the
-			// server omits error_code (older builds, generic ValidationError),
-			// keep the category as `parent_not_ready` since it's the most
-			// common 409 in the offline pipeline AND it routes to the right
-			// per-category Edit & Retry flow (parent inspector).
+			// 409 is the dependency / conflict bucket: parent_not_ready,
+			// siblings_not_ready, stock_shortage, batch_or_serial_conflict.
+			//
+			// The two dependency codes PARK. MAX_ATTEMPTS was sized for
+			// transient transport failures; a closing waiting on its invoices
+			// may legitimately wait far longer, and every attempt is a wasted
+			// round-trip that burns the budget until the row lands in
+			// needs_review anyway — the very state parking exists to avoid.
+			// The outbox already has the machinery and the pre-send gate
+			// already uses it, so route into that rather than inventing a
+			// second path. Parking does NOT consume an attempt.
+			//
+			// A generic 409 with no error_code is NOT assumed transient — the
+			// old `parent_not_ready` default was a guess and must not become
+			// an automatic park.
+			if (errorCode === "siblings_not_ready" || errorCode === "parent_not_ready") {
+				return {
+					kind: "park",
+					reason:
+						errorCode === "siblings_not_ready"
+							? "waiting_for_siblings"
+							: "waiting_for_parent",
+					detail,
+					missingOfflineIds: extractMissingOfflineIds(err),
+				};
+			}
 			return {
 				kind: "needsReview",
-				category: errorCodeToCategory(errorCode, "parent_not_ready"),
+				category: errorCodeToCategory(errorCode, "validation_error"),
 				detail,
 			};
 		}
@@ -1487,6 +1516,19 @@ function classifySendError(
 		return { kind: "retry", category: "timeout", detail };
 	}
 	return { kind: "retry", category: "network_error", detail };
+}
+
+/**
+ * Pull `missing_offline_ids` off a server dependency error. The server sends
+ * it on siblings_not_ready (offline.py:1607-1611) so the reconciliation
+ * workspace can show the cashier exactly which invoices a close is waiting
+ * on. Absent on older server builds — an empty array is fine.
+ */
+function extractMissingOfflineIds(err: unknown): string[] {
+	if (!err || typeof err !== "object") return [];
+	const raw = (err as Record<string, unknown>).missing_offline_ids;
+	if (!Array.isArray(raw)) return [];
+	return raw.filter((v): v is string => typeof v === "string" && v.length > 0);
 }
 
 /**

--- a/frontend/src/offline/sync.ts
+++ b/frontend/src/offline/sync.ts
@@ -638,7 +638,18 @@ export class SyncScheduler {
 						result.detail,
 					);
 				} else if (result.kind === "park") {
-					await markBlocked(entry.offline_id, result.reason);
+					// Persist WHAT the row is waiting on, not just that it is
+					// waiting — the reconciliation workspace reads
+					// `last_error_detail`. Passing only two args would default
+					// `detail` to null and wipe any prior error text.
+					const waitingOn = result.missingOfflineIds.length
+						? ` (waiting on: ${result.missingOfflineIds.join(", ")})`
+						: "";
+					await markBlocked(
+						entry.offline_id,
+						result.reason,
+						`${result.detail}${waitingOn}`,
+					);
 					cycle.parked = (cycle.parked ?? 0) + 1;
 				} else {
 					// Mark needs_review first (stable terminal state) before attempting

--- a/frontend/src/offline/sync.ts
+++ b/frontend/src/offline/sync.ts
@@ -1519,16 +1519,28 @@ function classifySendError(
 }
 
 /**
- * Pull `missing_offline_ids` off a server dependency error. The server sends
- * it on siblings_not_ready (offline.py:1607-1611) so the reconciliation
- * workspace can show the cashier exactly which invoices a close is waiting
- * on. Absent on older server builds — an empty array is fine.
+ * Pull `missing_offline_ids` off a server dependency error so the
+ * reconciliation workspace can show the cashier exactly which invoices a
+ * close is waiting on.
+ *
+ * `_throw` (offline.py) puts structured fields under `details`, so that is
+ * where this normally lives; the top-level read is a cheap fallback for any
+ * build that flattens the payload. Same two-shape handling as
+ * `extractServerDocName` above.
  */
 function extractMissingOfflineIds(err: unknown): string[] {
 	if (!err || typeof err !== "object") return [];
-	const raw = (err as Record<string, unknown>).missing_offline_ids;
-	if (!Array.isArray(raw)) return [];
-	return raw.filter((v): v is string => typeof v === "string" && v.length > 0);
+	const e = err as Record<string, unknown>;
+	const fromTop = e.missing_offline_ids;
+	if (Array.isArray(fromTop)) {
+		return fromTop.filter((v): v is string => typeof v === "string" && v.length > 0);
+	}
+	const details = e.details as Record<string, unknown> | undefined;
+	const fromDetails = details?.missing_offline_ids;
+	if (Array.isArray(fromDetails)) {
+		return fromDetails.filter((v): v is string => typeof v === "string" && v.length > 0);
+	}
+	return [];
 }
 
 /**

--- a/frontend/src/offline/types.ts
+++ b/frontend/src/offline/types.ts
@@ -172,6 +172,13 @@ export interface ShiftRow {
 	closing_notes: string | null;
 	closed_at: number | null;
 	closing_server_name: string | null;
+	/**
+	 * Offline_id of the queued closing entry this shift is waiting on.
+	 * Set while `status === "closed_pending_sync"`, cleared once the closing
+	 * syncs. Distinct from `closing_server_name`, which is the SERVER's name
+	 * for the closing and only exists after sync.
+	 */
+	pending_closing_offline_id: string | null;
 	status: ShiftStatus;
 	manager_approval_required: boolean;
 }
@@ -193,6 +200,13 @@ export interface StoredShiftRow {
 	variance_at_sync: { by_mop: Record<string, number>; total: number } | null;
 	closed_at: number | null;
 	closing_server_name: string | null;
+	/**
+	 * Offline_id of the queued closing entry this shift is waiting on.
+	 * Set while `status === "closed_pending_sync"`, cleared once the closing
+	 * syncs. Distinct from `closing_server_name`, which is the SERVER's name
+	 * for the closing and only exists after sync.
+	 */
+	pending_closing_offline_id: string | null;
 	status: ShiftStatus;
 	manager_approval_required: boolean;
 	// Encrypted siblings — may be null when the shift is still open.

--- a/frontend/src/offline/types.ts
+++ b/frontend/src/offline/types.ts
@@ -355,4 +355,6 @@ export interface ReadCache {
 		key: string,
 	): Promise<{ data: T; cachedAt: number } | null>;
 	write<T>(key: string, data: T, ttlMs?: number): Promise<void>;
+	/** Drop a single cached key from both layers. Used on logout. */
+	invalidate(cacheKey: string): Promise<void>;
 }

--- a/frontend/src/utils/call-registry.ts
+++ b/frontend/src/utils/call-registry.ts
@@ -620,6 +620,25 @@ export const methodRegistry: Record<string, MethodConfig> = {
 				invoice_offline_ids: invoiceOfflineIds,
 			};
 
+			// Anchor the queued closing to its shift.
+			//
+			// Two client-side consumers read this off the queued row:
+			//   - Pos.vue `matchesShift()` (the duplicate-close guard)
+			//   - outbox.ts `readInnerShiftName()` (the strict-closure gate)
+			// Without it, both silently fail for online-opened shifts and the cashier
+			// can enqueue a second closing that the server later rejects.
+			//
+			// Stamp ONLY when the shift was opened online. For an offline-opened shift
+			// `cs.pos_opening_shift` holds the provisional "OFFLINE-OPN-..." name, which
+			// is not a server link and must never be written as one — that case is
+			// already anchored by `shift_offline_id` on the outbox row.
+			//
+			// The server overwrites this field at offline.py:1877 regardless, so
+			// stamping it changes nothing server-side.
+			if (!openingOfflineId && openingServerName) {
+				doc.pos_opening_shift = openingServerName;
+			}
+
 			// Parents the scheduler waits on before sending: the opening shift
 			// (must be synced first so its name resolves) and every invoice in
 			// the shift (strict closure).

--- a/frontend/src/utils/call-registry.ts
+++ b/frontend/src/utils/call-registry.ts
@@ -140,6 +140,9 @@ function todayIso(): string {
 
 const HOUR = 60 * 60 * 1000;
 
+/** Stable cache key for `get_opening_dialog_data`. Must match DURABLE_KEYS. */
+export const OPENING_DIALOG_CACHE_KEY = "offline.opening_dialog_data";
+
 /**
  * The canonical registry. Names are the exact server method paths.
  *
@@ -203,7 +206,16 @@ export const methodRegistry: Record<string, MethodConfig> = {
 		intent: "read",
 		offline: false,
 	},
-	"pospire.pospire.api.posapp.get_opening_dialog_data": { intent: "read", offline: false },
+	// Opening-dialog reference data. Durable-cached (see DURABLE_KEYS in
+	// offline/read-cache.ts) so it survives a reload — the cashier often
+	// reaches this dialog only after an offline close, on a fresh page load.
+	// Both call sites MUST pass OPENING_DIALOG_CACHE_KEY as opts.cacheKey; the
+	// default arg-hashed key is neither stable nor allowlistable.
+	"pospire.pospire.api.posapp.get_opening_dialog_data": {
+		intent: "read",
+		offline: true,
+		cacheTTLMs: 24 * HOUR,
+	},
 	"pospire.pospire.api.posapp.check_opening_shift": { intent: "read", offline: false },
 	"pospire.pospire.api.posapp.get_draft_invoices": { intent: "read", offline: false },
 	"pospire.pospire.api.posapp.search_orders": { intent: "read", offline: false },

--- a/frontend/src/utils/call-registry.ts
+++ b/frontend/src/utils/call-registry.ts
@@ -192,6 +192,16 @@ export const methodRegistry: Record<string, MethodConfig> = {
 		offline: true,
 		cacheTTLMs: 24 * HOUR,
 	},
+	// Opening-dialog reference data. Durable-cached (see DURABLE_KEYS in
+	// offline/read-cache.ts) so it survives a reload — the cashier often
+	// reaches this dialog only after an offline close, on a fresh page load.
+	// Both call sites MUST pass OPENING_DIALOG_CACHE_KEY as opts.cacheKey; the
+	// default arg-hashed key is neither stable nor allowlistable.
+	"pospire.pospire.api.posapp.get_opening_dialog_data": {
+		intent: "read",
+		offline: true,
+		cacheTTLMs: 24 * HOUR,
+	},
 
 	// -----------------------------------------------------------------------
 	// Reads — LIVE ONLY (P-4: server stays authoritative)
@@ -205,16 +215,6 @@ export const methodRegistry: Record<string, MethodConfig> = {
 	"pospire.pospire.api.posapp.get_applicable_delivery_charges": {
 		intent: "read",
 		offline: false,
-	},
-	// Opening-dialog reference data. Durable-cached (see DURABLE_KEYS in
-	// offline/read-cache.ts) so it survives a reload — the cashier often
-	// reaches this dialog only after an offline close, on a fresh page load.
-	// Both call sites MUST pass OPENING_DIALOG_CACHE_KEY as opts.cacheKey; the
-	// default arg-hashed key is neither stable nor allowlistable.
-	"pospire.pospire.api.posapp.get_opening_dialog_data": {
-		intent: "read",
-		offline: true,
-		cacheTTLMs: 24 * HOUR,
 	},
 	"pospire.pospire.api.posapp.check_opening_shift": { intent: "read", offline: false },
 	"pospire.pospire.api.posapp.get_draft_invoices": { intent: "read", offline: false },

--- a/frontend/src/utils/call.ts
+++ b/frontend/src/utils/call.ts
@@ -21,9 +21,10 @@
 // `call()` — see the function for why (structured server error fields need to
 // survive the request). This file no longer needs a frappe-ui import as a
 // result, but the `no-restricted-imports` override for it in eslint.config.js
-// is left in place: it still legitimately covers call-registry.ts, and a
-// future change here that needs a frappe-ui helper directly is expected to
-// use it rather than re-litigate the boundary.
+// is left in place: it still legitimately covers the two remaining direct
+// importers (src/main.js and src/offline/connectivity.ts), and a future
+// change here that needs a frappe-ui helper directly is expected to use it
+// rather than re-litigate the boundary.
 import {
 	getMethodConfig,
 	isReadConfig,
@@ -735,6 +736,12 @@ async function buildLiveFetchError(
 			messages = [];
 		}
 	}
+	// `_server_messages` is server-controlled and only ever JSON-encodes to an
+	// array in practice, but JSON.parse doesn't guarantee that shape (e.g.
+	// `"{}"` parses to a plain object). Without this guard, `.concat`/`.map`
+	// below would throw a TypeError that escapes uncaught and gets
+	// misclassified as network_error — which would enqueue a 4xx write.
+	if (!Array.isArray(messages)) messages = [];
 	messages = messages.concat(parsed?.message as unknown);
 	messages = messages
 		.map((m) => {
@@ -771,8 +778,15 @@ async function buildLiveFetchError(
  * is the more direct source of truth when both are present.
  */
 function classifyFetchError(err: unknown): "network_error" | "http_4xx" | "http_5xx" {
+	// An AbortError is the caller cancelling, not the server being
+	// unreachable. Classifying it as network_error would count a user
+	// cancel toward the offline transition, serve stale cache instead of
+	// rejecting, and — worst — enqueue the very write that was cancelled.
+	// Rethrow here (not return a fourth classification) so both call sites
+	// propagate the abort unclassified and skip reportRequestOutcome entirely.
+	if (err instanceof Error && err.name === "AbortError") throw err;
 	// Defensive parsing — a rejected fetch() (e.g. `TypeError: Failed to
-	// fetch`, or an AbortError) won't have any of these fields.
+	// fetch`) won't have any of these fields.
 	if (!err || typeof err !== "object") return "network_error";
 	const e = err as Record<string, unknown>;
 	const response = e.response as { status?: unknown } | undefined;

--- a/frontend/src/utils/call.ts
+++ b/frontend/src/utils/call.ts
@@ -17,10 +17,13 @@
  *   - Request batching / response transformation.
  */
 
-// This file is the ONE exception to the `no-restricted-imports` ban on
-// `frappe-ui`. See eslint.config.js override.
-import { call as frappeUiCall } from "frappe-ui";
-
+// liveFetch() below performs its own fetch() rather than importing frappe-ui's
+// `call()` — see the function for why (structured server error fields need to
+// survive the request). This file no longer needs a frappe-ui import as a
+// result, but the `no-restricted-imports` override for it in eslint.config.js
+// is left in place: it still legitimately covers call-registry.ts, and a
+// future change here that needs a frappe-ui helper directly is expected to
+// use it rather than re-litigate the boundary.
 import {
 	getMethodConfig,
 	isReadConfig,
@@ -626,28 +629,154 @@ function getDeviceId(): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Invoke frappe-ui's `call` with the right shape. On success, mark the
- * connectivity detector with a recent-success; classification of errors is
- * handled by the caller so read/write paths can apply their own policy.
+ * Perform the live HTTP request. Mirrors frappe-ui's `call.js` request shape
+ * (path, method, headers, body, CSRF header gating) exactly, so session auth
+ * keeps working — but does its OWN fetch instead of delegating to frappe-ui.
+ *
+ * Why: frappe-ui's `call()` reads the error body with `.text()`, parses out
+ * only `exc_type`/`exc`/`messages`/`status`, and discards the parsed object —
+ * the body can't be re-read afterwards. The server's `error_code`, `details`,
+ * and `http_status_code` (set by `_throw` in offline.py) never survive that
+ * trip, which left every `error_code`-based branch in `sync.ts`'s replay
+ * router permanently dead (see task-11 brief). Owning the fetch here lets us
+ * attach the structured fields to the thrown Error while keeping frappe-ui's
+ * exact success/error message semantics for everything else.
+ *
+ * On success, marks the connectivity detector with a recent-success. On
+ * failure, throws and does NOT report an outcome — callers (runRead/runWrite)
+ * classify the error and report failure themselves; reporting here too would
+ * double-count it.
  */
 async function liveFetch<T>(opts: CallOptions): Promise<T> {
-	// frappe-ui's `call` resolves to the response `message` body for 2xx,
-	// and rejects with an object carrying HTTP details for non-2xx.
-	// We don't try to unify that here — we just classify in classifyFetchError.
-	// NOTE: abortSignal is accepted on the options but frappe-ui's call
-	// signature is (method, args). AbortSignal wiring lands with Agent 3
-	// once frappe-ui's request layer is replaced by a fetch-abortable client.
-	const result = (await frappeUiCall(opts.method, opts.args ?? {})) as T;
-	connectivity.reportRequestOutcome("success");
-	return result;
+	const path = opts.method.startsWith("/") ? opts.method : `/api/method/${opts.method}`;
+
+	const headers: Record<string, string> = {
+		Accept: "application/json",
+		"Content-Type": "application/json; charset=utf-8",
+		"X-Frappe-Site-Name": window.location.hostname,
+	};
+	// window.csrf_token isn't declared on lib.dom's Window type; frappe-ui
+	// itself reads it the same untyped way (it ships as plain JS).
+	const csrfToken = (window as Window & { csrf_token?: string }).csrf_token;
+	if (csrfToken && csrfToken !== "{{ csrf_token }}") {
+		headers["X-Frappe-CSRF-Token"] = csrfToken;
+	}
+
+	const response = await fetch(path, {
+		method: "POST",
+		headers,
+		body: JSON.stringify(opts.args ?? {}),
+		signal: opts.abortSignal,
+	});
+
+	if (response.ok) {
+		const data = (await response.json()) as { message?: T };
+		connectivity.reportRequestOutcome("success");
+		return data.message as T;
+	}
+
+	throw await buildLiveFetchError(opts.method, response);
 }
 
-/** Classify an error thrown by frappe-ui's `call`. */
+/**
+ * Build the Error thrown for a non-2xx response. Reproduces frappe-ui's
+ * `call.js` message/`messages` construction (around its lines 53-84) so
+ * downstream consumers reading `e.messages` see the same shape as before,
+ * then attaches the structured fields frappe-ui dropped.
+ *
+ * The body is read via `.text()` exactly once — a `Response` body stream can
+ * only be consumed a single time, so `.json()` and `.text()` can never both
+ * be called on it. A non-JSON body (e.g. an HTML 502 from a proxy) is a
+ * `JSON.parse` failure we catch, not a crash: `parsed` stays `undefined` and
+ * every field sourced from it is correctly `undefined` rather than throwing.
+ */
+async function buildLiveFetchError(
+	method: string,
+	response: Response,
+): Promise<Error & Record<string, unknown>> {
+	const raw = await response.text();
+	let parsed: Record<string, unknown> | undefined;
+	try {
+		parsed = JSON.parse(raw) as Record<string, unknown>;
+	} catch {
+		// Non-JSON error body (proxy HTML, gateway timeout page). The structured
+		// fields simply won't be there; everything else must still work.
+	}
+
+	const excType = parsed?.exc_type as string | undefined;
+	const errorMessage = parsed?._error_message as string | undefined;
+	const e = new Error([method, excType, errorMessage].filter(Boolean).join(" ")) as Error &
+		Record<string, unknown>;
+
+	e.exc_type = excType;
+
+	// frappe-ui: `exc` is JSON-parsed and its first element taken — but only
+	// when it actually parses to an array. A stray parse failure (or a body
+	// that JSON-parses to something else) must not escape as a thrown error.
+	let exc: unknown = parsed?.exc;
+	if (typeof exc === "string") {
+		try {
+			const parsedExc: unknown = JSON.parse(exc);
+			exc = Array.isArray(parsedExc) ? parsedExc[0] : parsedExc;
+		} catch {
+			// Leave `exc` as the raw (unparsed) string, same as frappe-ui.
+		}
+	}
+	e.exc = exc;
+
+	e.status = response.status;
+	e.response = response;
+
+	let messages: unknown[] = [];
+	if (typeof parsed?._server_messages === "string") {
+		try {
+			messages = JSON.parse(parsed._server_messages) as unknown[];
+		} catch {
+			messages = [];
+		}
+	}
+	messages = messages.concat(parsed?.message as unknown);
+	messages = messages
+		.map((m) => {
+			if (typeof m !== "string") return m;
+			try {
+				return (JSON.parse(m) as { message?: unknown })?.message;
+			} catch {
+				return m;
+			}
+		})
+		.filter(Boolean);
+	if (!messages.length) {
+		messages = errorMessage ? [errorMessage] : ["Internal Server Error"];
+	}
+	e.messages = messages;
+
+	// New: fields `_throw` (pospire/api/offline.py) sets on the response that
+	// frappe-ui's call() parsed out of the body and then dropped. `sync.ts`'s
+	// replay router reads these to decide retry/park/fail — see task-11 brief.
+	e.error_code = parsed?.error_code;
+	e.details = parsed?.details;
+	e.http_status_code = (parsed?.http_status_code as number | undefined) ?? response.status;
+
+	return e;
+}
+
+/**
+ * Classify an error thrown by `liveFetch`/`buildLiveFetchError` above.
+ *
+ * `status`/`response` are now set by code in THIS module (not frappe-ui's
+ * `frappeRequest.js`), so both are reliable: `status` is always the real
+ * numeric HTTP status, and `response.status` is the same value read off the
+ * actual `Response`. The `response` check is kept first regardless, since it
+ * is the more direct source of truth when both are present.
+ */
 function classifyFetchError(err: unknown): "network_error" | "http_4xx" | "http_5xx" {
-	// frappe-ui rejects with various shapes — defensive parsing.
+	// Defensive parsing — a rejected fetch() (e.g. `TypeError: Failed to
+	// fetch`, or an AbortError) won't have any of these fields.
 	if (!err || typeof err !== "object") return "network_error";
 	const e = err as Record<string, unknown>;
-	const statusCandidates = [e.status, e.statusCode, e.httpStatus];
+	const response = e.response as { status?: unknown } | undefined;
+	const statusCandidates = [response?.status, e.status, e.statusCode, e.httpStatus];
 	for (const s of statusCandidates) {
 		if (typeof s === "number") {
 			if (s >= 500 && s < 600) return "http_5xx";

--- a/pospire/patches.txt
+++ b/pospire/patches.txt
@@ -6,3 +6,4 @@
 # Patches added in this section will be executed after doctypes are migrated
 pospire.patches.v1_1.remove_denomination_breakdown_at_closing_field
 pospire.patches.v1_1.add_strict_closure_compound_index
+pospire.patches.v1_1.repair_unclosed_opening_shifts

--- a/pospire/patches/v1_1/repair_unclosed_opening_shifts.py
+++ b/pospire/patches/v1_1/repair_unclosed_opening_shifts.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, Promantia Business Solutions PVT Ltd and Contributors
+# See license.txt
+
+"""Repair POS Opening Shifts left Open despite a submitted closing.
+
+Before the closure post-condition landed in `offline.create_closing_entry`,
+a queued closing could be accepted by the server while the opening shift
+stayed Open - the client saw `synced` and the shift was never closable
+again. Nothing replays those entries, so historical rows need this sweep.
+
+Repairs only the unambiguous case: EXACTLY ONE submitted closing against
+the opening. More than one is an accounting question about which close is
+authoritative; those are logged and left alone.
+
+Idempotent - re-running against a correct shift is a no-op.
+"""
+
+import frappe
+
+from pospire.pospire.api.offline import _ensure_opening_closed
+
+
+def execute():
+	openings = frappe.get_all(
+		"POS Opening Shift",
+		filters={"docstatus": 1},
+		or_filters=[
+			["status", "=", "Open"],
+			["pos_closing_shift", "is", "not set"],
+		],
+		pluck="name",
+	)
+	if not openings:
+		return
+
+	repaired = 0
+	ambiguous = []
+
+	for opening_name in openings:
+		closings = frappe.get_all(
+			"POS Closing Shift",
+			filters={"pos_opening_shift": opening_name, "docstatus": 1},
+			pluck="name",
+		)
+		if not closings:
+			continue
+		if len(closings) > 1:
+			ambiguous.append((opening_name, closings))
+			continue
+		if _ensure_opening_closed(opening_name, closings[0]):
+			repaired += 1
+
+	if repaired:
+		print(f"repair_unclosed_opening_shifts: repaired {repaired} opening shift(s)")
+
+	for opening_name, closings in ambiguous:
+		frappe.log_error(
+			title="POS Opening Shift has multiple submitted closings",
+			message=(
+				f"Opening shift {opening_name} has {len(closings)} submitted "
+				f"closing shifts: {', '.join(closings)}. "
+				"Not repaired automatically - decide which close is authoritative."
+			),
+		)

--- a/pospire/pospire/api/offline.py
+++ b/pospire/pospire/api/offline.py
@@ -1814,6 +1814,35 @@ def _enrich_closing_payload(
 	payload["payment_reconciliation"] = new_recon
 
 
+def _ensure_opening_closed(opening_name: str, closing_name: str) -> bool:
+	"""Assert `opening_name` is Closed against `closing_name`.
+
+	Some _idempotent_submit branches (replay, dup-rollback) skip
+	POSClosingShift.on_submit, leaving the opening shift Open after a
+	"synced" response. Mirrors the repair in submit_closing_shift.
+	Idempotent - no-op (incl. `modified`) if already correct.
+
+	Returns True if a repair was applied.
+	"""
+	current = frappe.db.get_value(
+		"POS Opening Shift",
+		opening_name,
+		["status", "pos_closing_shift"],
+		as_dict=True,
+	)
+	if not current:
+		return False
+	if current.status == "Closed" and current.pos_closing_shift == closing_name:
+		return False
+
+	opening = frappe.get_doc("POS Opening Shift", opening_name)
+	opening.pos_closing_shift = closing_name
+	opening.set_status()
+	opening.flags.ignore_permissions = True
+	opening.save()
+	return True
+
+
 @frappe.whitelist()
 def create_closing_entry(
 	data: dict | str,
@@ -1900,6 +1929,13 @@ def create_closing_entry(
 		submit=True,
 		owner_user=owner_user,
 	)
+
+	# Assert closure post-condition on every branch (fresh, replay, dup-race).
+	closing_name = result.get("name")
+	if closing_name and cint(result.get("docstatus")) == 1:
+		if _ensure_opening_closed(opening_name, closing_name):
+			result["opening_shift_repaired"] = True
+
 	if auto_included_invoice_offline_ids:
 		result["auto_included_invoice_offline_ids"] = auto_included_invoice_offline_ids
 		result["validated_invoice_offline_ids"] = canonical_invoice_offline_ids

--- a/pospire/pospire/api/posapp.py
+++ b/pospire/pospire/api/posapp.py
@@ -100,10 +100,18 @@ def get_opening_dialog_data() -> dict:
 		pos_profiles_list.append(i.name)
 
 	payment_method_table = "POS Payment Method"
+	# Explicit field list, not fields=["*"]. This response is durable-cached
+	# client-side (unencrypted Dexie `metadata` table, see DURABLE_KEYS in
+	# frontend/src/offline/read-cache.ts) on the premise that it carries no
+	# PII. "*" on a child table also returns `owner`/`modified_by` (staff
+	# email addresses) and would silently re-introduce PII the moment this
+	# doctype gains a new field. Only "parent" (used below AND by both
+	# OpeningDialog consumers to match a profile) and "mode_of_payment"
+	# (the only other field either consumer reads) are needed.
 	data["payments_method"] = frappe.get_list(
 		payment_method_table,
 		filters={"parent": ["in", pos_profiles_list]},
-		fields=["*"],
+		fields=["parent", "mode_of_payment"],
 		limit_page_length=0,
 		order_by="parent",
 		ignore_permissions=True,

--- a/pospire/pospire/api/posapp.py
+++ b/pospire/pospire/api/posapp.py
@@ -116,30 +116,36 @@ def get_opening_dialog_data() -> dict:
 	for profile in data["pos_profiles_data"]:
 		profile_doc = frappe.get_cached_doc("POS Profile", profile.name)
 
-		if profile_doc.get("custom_enable_cash_denominations"):
-			cash_mode = profile_doc.get("posa_cash_mode_of_payment") or "Cash"
-			denominations = []
-			for d in profile_doc.get("custom_denominations", []):
-				denominations.append(
-					{
-						"denomination": d.denomination,
-						"denomination_name": frappe.get_cached_value(
-							"POS Denomination",
-							d.denomination,
-							"denomination_name",
-						),
-						"denomination_value": d.denomination_value,
-						"currency": d.currency,
-						"display_order": d.display_order,
-					}
-				)
-			denominations.sort(key=lambda x: x.get("display_order") or 0)
-			if denominations:
-				data["denomination_config"][profile.name] = {
-					"enabled": True,
-					"cash_mode": cash_mode,
-					"denominations": denominations,
+		if not profile_doc.get("custom_enable_cash_denominations"):
+			continue
+
+		denominations = []
+		for d in profile_doc.get("custom_denominations", []):
+			denominations.append(
+				{
+					"denomination": d.denomination,
+					"denomination_name": frappe.get_cached_value(
+						"POS Denomination",
+						d.denomination,
+						"denomination_name",
+					),
+					"denomination_value": d.denomination_value,
+					"currency": d.currency,
+					"display_order": d.display_order,
 				}
+			)
+		denominations.sort(key=lambda x: x.get("display_order") or 0)
+
+		# Emit the policy even when `denominations` is empty. "Enabled but
+		# unconfigured" is a misconfiguration the cashier should see, not a
+		# reason to silently render the dialog as if denominations were off.
+		# Collapsing the two states is what forced the client to guess.
+		data["denomination_config"][profile.name] = {
+			"enabled": True,
+			"cash_mode": profile_doc.get("posa_cash_mode_of_payment") or "Cash",
+			"denominations": denominations,
+			"config_version": str(profile_doc.modified),
+		}
 
 	return data
 

--- a/pospire/pospire/doctype/pos_closing_shift/pos_closing_shift.py
+++ b/pospire/pospire/doctype/pos_closing_shift/pos_closing_shift.py
@@ -93,14 +93,26 @@ class POSClosingShift(Document):
 		# If denominations not used, don't override manual closing amount
 		if not self.denomination_details:
 			return
-		total = 0
 
+		# The cash mode of payment is profile-configurable. Matching the literal
+		# "Cash" silently wrote the denomination total onto nothing whenever a
+		# site renamed it (e.g. "Cash - PL").
+		cash_mode = (
+			frappe.get_cached_value(
+				"POS Profile",
+				self.pos_profile,
+				"posa_cash_mode_of_payment",
+			)
+			or "Cash"
+		)
+
+		total = 0
 		for d in self.denomination_details:
 			d.closing_amount = (d.denomination_value or 0) * (d.closing_quantity or 0)
 			total += d.closing_amount
 
 		for p in self.payment_reconciliation:
-			if p.mode_of_payment == "Cash":
+			if p.mode_of_payment == cash_mode:
 				p.closing_amount = total
 
 	def on_submit(self):


### PR DESCRIPTION
## Summary

Phase 1 of the offline shift lifecycle work. Fixes two field-reported bugs in offline POS shift handling.

**Issue 1 — Opening dialog renders without the cash denomination grid**, most often after an offline/online round trip. The dialog's config came from a non-durable cache, so a reload while offline produced a config-less dialog with no way back.

**Issue 2 — Closing a shift offline left the POS Opening Shift `Open`.** The queued closing synced and the client marked it `synced`, but the server never flipped the opening. Reopening showed the same session; a second close appeared to succeed and saved nothing.

## Approach

- Queued closing entries are now stamped with their `pos_opening_shift` at enqueue time, so the server can resolve the opening even when the client only knows an `offline_id`.
- `_ensure_opening_closed(opening_name, closing_name)` runs on every `_idempotent_submit` return path, making "the opening is closed" a post-condition of a successful closing rather than a hopeful side effect.
- Every shift gets a durable `db.shifts` row with a lifecycle UUID, so closing-pending state survives reloads and multiple shifts.
- Dependency 409s (`siblings_not_ready` / `parent_not_ready`) are parked and woken rather than burning retry budget.
- `liveFetch` was rewritten onto a transport that preserves `error_code`, `details` and `http_status_code`, which the previous implementation discarded. `missing_offline_ids` is read from `details` as well as top level.
- A migration patch (`repair_unclosed_opening_shifts`) sweeps historical openings left `Open` against exactly one submitted closing. It is idempotent, and it deliberately does not guess when there are multiple submitted closings; it logs those instead.

## Notable review catches

Worth reading these diffs specifically, since each was a silent failure:

- `registerOpenedShift` awaited `crypto.subtle` inside a Dexie transaction, which triggers `PrematureCommitError`. Every call threw into a `console.warn` and the feature was completely dead while build, lint and tests all stayed green. Fixed by splitting `buildStoredShift` (crypto, outside) from `putShiftIfAbsent` (transaction).
- `markBlocked` was being called with two args against a three-arg signature, wiping `last_error_detail` to null.
- Queued-invoice cash netting went through three revisions. `inner.change_amount` does not exist on the queued payload; `posa_submit_data.total_change` is zeroed behind `if (!is_cashback)`, which restored the original bug on `use_cashback=0` profiles. The landed version derives change from `sum(payments[].amount) + loyalty/conversion_rate − (rounded_total || grand_total)`, clamped at zero.

## Files

24 commits, 30 files. Backend: `api/offline.py`, `api/posapp.py`, `pos_closing_shift.py`, one new patch. Frontend: `offline/shift-lifecycle.ts` (new), `utils/call.ts`, `offline/sync.ts`, `offline/outbox.ts`, `OpeningDialog.vue`, `Pos.vue`.

## Testing

Manually tested against a live site. Automated coverage is one new file, `__tests__/utils/call-transport.test.ts` (6 tests), covering the transport rewrite, since that change is invisible to the existing suite. Full suite: 121 passing.

## Deploy notes

`bench migrate` will run `repair_unclosed_opening_shifts` on every site. It touches submitted POS Opening Shift documents. Idempotent, and safe to re-run.

## Merging

Please use **Create a merge commit**, not squash. PR for Phase 2 is stacked on this branch and will retarget automatically once this lands.
