### PR TITLE
fix(offline): contribution ledger — queued sales in the close-shift dialog

### DIFF
--- a/frontend/__tests__/helpers/offline-fixture.ts
+++ b/frontend/__tests__/helpers/offline-fixture.ts
@@ -41,12 +41,24 @@ export async function clearAllTables(): Promise<void> {
 	try {
 		await db.transaction(
 			"rw",
-			[db.items, db.customers, db.shifts, db.outbox, db.metadata, db._health],
+			[
+				db.items,
+				db.customers,
+				db.shifts,
+				db.outbox,
+				db.metadata,
+				db._health,
+				db.contributions,
+			],
 			async () => {
 				await db.items.clear();
 				await db.customers.clear();
 				await db.shifts.clear();
 				await db.outbox.clear();
+				// Added in schema v2. Left out, contribution rows leak between
+				// test cases and the first test written against the ledger
+				// passes for the wrong reason.
+				await db.contributions.clear();
 				// Keep the crypto key rows alive — the active key was registered at
 				// init; wiping metadata would leave the module with a stale key id.
 				// We delete everything else by key.

--- a/frontend/src/components/Navbar.vue
+++ b/frontend/src/components/Navbar.vue
@@ -77,7 +77,7 @@
           variant="tonal"
           color="error"
           size="small"
-          :title="__('You are offline — sales continue locally')"
+          :title="__('You are offline. Sales continue locally')"
         >
           <v-icon start size="small">mdi-cloud-off-outline</v-icon>
           {{ __('Offline') }}
@@ -88,7 +88,7 @@
           variant="tonal"
           color="warning"
           size="small"
-          :title="__('Connectivity unstable — saving locally')"
+          :title="__('Connectivity unstable. Saving locally')"
         >
           <v-icon start size="small">mdi-access-point-network-off</v-icon>
           {{ __('Unstable') }}

--- a/frontend/src/components/offline/OfflineBanner.vue
+++ b/frontend/src/components/offline/OfflineBanner.vue
@@ -118,15 +118,15 @@ export default defineComponent({
         case "needs_review":
           return `${needsReviewCount.value} transaction${needsReviewCount.value === 1 ? "" : "s"} need attention`;
         case "chained_shifts":
-          return `${unsyncedOpeningCount.value} unsynced shift${unsyncedOpeningCount.value === 1 ? "" : "s"} stacked — reconnect before opening another`;
+          return `${unsyncedOpeningCount.value} unsynced shift${unsyncedOpeningCount.value === 1 ? "" : "s"} stacked. Reconnect before opening another`;
         case "offline": {
           if (oldestPendingMinutes.value !== null && oldestPendingMinutes.value >= 30) {
-            return `You are offline — ${oldestPendingMinutes.value} min`;
+            return `You are offline: ${oldestPendingMinutes.value} min`;
           }
-          return `You are offline — ${queuedCount.value} transaction${queuedCount.value === 1 ? "" : "s"} queued`;
+          return `You are offline: ${queuedCount.value} transaction${queuedCount.value === 1 ? "" : "s"} queued`;
         }
         case "degraded":
-          return "Connectivity unstable — saving locally";
+          return "Connectivity unstable: saving locally";
         case "syncing":
           return `Syncing ${inFlightCount.value || pendingCount.value} transaction${(inFlightCount.value || pendingCount.value) === 1 ? "" : "s"}…`;
         default:

--- a/frontend/src/components/offline/OfflineBanner.vue
+++ b/frontend/src/components/offline/OfflineBanner.vue
@@ -84,7 +84,7 @@ export default defineComponent({
       try {
         const ok = await connectivityModule.forcePingNow();
         if (!ok) {
-          toast.warning(__("Still offline — server unreachable"), { autoClose: 3000 });
+          toast.warning(__("Still offline: server unreachable"), { autoClose: 3000 });
         }
         // On success the connectivity transition fires; banner auto-hides.
       } finally {

--- a/frontend/src/components/offline/OfflineSyncStatus.vue
+++ b/frontend/src/components/offline/OfflineSyncStatus.vue
@@ -87,7 +87,7 @@
     >
       {{
         __(
-          '{0} entries queued — drain may take several minutes. Tap Pause if you need to keep taking orders without the sync noise.',
+          '{0} entries queued. Drain may take several minutes. Tap Pause if you need to keep taking orders without the sync noise.',
           [queuedCount]
         )
       }}
@@ -200,7 +200,7 @@
                 location="left"
                 :text="
                   __(
-                    'Copy the OSR ID — share it with a manager so they can locate this entry in the Desk recovery queue.'
+                    'Copy the OSR ID and share it with a manager so they can locate this entry in the Desk recovery queue.'
                   )
                 "
               >

--- a/frontend/src/components/offline/OfflineSyncStatus.vue
+++ b/frontend/src/components/offline/OfflineSyncStatus.vue
@@ -269,7 +269,7 @@
               </v-chip>
             </v-list-item-title>
             <v-list-item-subtitle>
-              {{ __('Awaiting handoff — will retry on next online cycle.') }}
+              {{ __('Awaiting handoff. Will retry on next online cycle.') }}
             </v-list-item-subtitle>
           </v-list-item>
         </v-list>

--- a/frontend/src/components/pos/ApprovalDialog.vue
+++ b/frontend/src/components/pos/ApprovalDialog.vue
@@ -274,7 +274,7 @@ export default {
 
 	computed: {
 		actionLabel() {
-			return this.itemName ? `${this.actionType} — ${this.itemName}` : this.actionType;
+			return this.itemName ? `${this.actionType}: ${this.itemName}` : this.actionType;
 		},
 		resultTitle() {
 			if (this.result === "Approved") return __("Approved");

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -28,7 +28,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Some contributions are not yet confirmed against the server. Affected invoices:") }}
+					{{ __("Some contributions are not yet recorded on the server. Affected invoices:") }}
 					{{ dialog_data.pospire_uncertain_count }}
 				</v-alert>
 				<v-data-table

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -12,14 +12,32 @@
 
 			<v-divider></v-divider>
 			<v-card-text class="px-6 py-4 overflow-y-auto" style="max-height:65vh;">
+				<!--
+					Two wordings, never both. The contribution ledger records
+					every sale, online and offline, so its figure is merely
+					unconfirmed. The outbox scan (`pospire_source === "scan"`)
+					is structurally blind to sales made earlier while online —
+					dropping that caveat there would present an incomplete
+					figure as a complete one. A stub with no discriminator at
+					all gets the cautious wording.
+				-->
 				<v-alert
-					v-if="dialog_data.pospire_offline_stub"
+					v-if="dialog_data.pospire_offline_stub && dialog_data.pospire_source === 'ledger'"
 					type="warning"
 					variant="tonal"
 					density="compact"
 					class="mb-3"
 				>
 					{{ __("Expected amounts are provisional — computed on this device and not yet confirmed by the server.") }}
+				</v-alert>
+				<v-alert
+					v-else-if="dialog_data.pospire_offline_stub"
+					type="warning"
+					variant="tonal"
+					density="compact"
+					class="mb-3"
+				>
+					{{ __("Expected amounts are provisional — computed on this device and not yet confirmed by the server. Sales made earlier while online are not included.") }}
 				</v-alert>
 				<v-alert
 					v-if="dialog_data.pospire_uncertain_count"

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -19,7 +19,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Expected amounts are provisional — totals could not be confirmed with the server. Sales made earlier while online are not included.") }}
+					{{ __("Expected amounts are provisional — computed on this device and not yet confirmed by the server.") }}
 				</v-alert>
 				<v-alert
 					v-if="dialog_data.pospire_uncertain_count"
@@ -28,7 +28,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Some queued invoices could not be confirmed with the server. Affected invoices:") }}
+					{{ __("Some contributions are not yet confirmed against the server. Affected invoices:") }}
 					{{ dialog_data.pospire_uncertain_count }}
 				</v-alert>
 				<v-data-table

--- a/frontend/src/components/pos/ClosingDialog.vue
+++ b/frontend/src/components/pos/ClosingDialog.vue
@@ -28,7 +28,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Expected amounts are provisional — computed on this device and not yet confirmed by the server.") }}
+					{{ __("Expected amounts are provisional: computed on this device and not yet confirmed by the server.") }}
 				</v-alert>
 				<v-alert
 					v-else-if="dialog_data.pospire_offline_stub"
@@ -37,7 +37,7 @@
 					density="compact"
 					class="mb-3"
 				>
-					{{ __("Expected amounts are provisional — computed on this device and not yet confirmed by the server. Sales made earlier while online are not included.") }}
+					{{ __("Expected amounts are provisional: computed on this device and not yet confirmed by the server. Sales made earlier while online are not included.") }}
 				</v-alert>
 				<v-alert
 					v-if="dialog_data.pospire_uncertain_count"

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -4305,7 +4305,7 @@ export default {
 			if (await this.isShiftLocked()) {
 				toast.warning(
 					__(
-						"This shift is closing — its closing entry is queued. Open a new shift before ringing up another sale.",
+						"This shift is closing. Its closing entry is queued. Open a new shift before ringing up another sale.",
 					),
 					{ autoClose: 5000 },
 				);

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -2835,7 +2835,7 @@ export default {
 			this.clear_invoice();
 			this.eventBus.emit("cart_emptied");
 			toast.info(
-				__("Draft saved offline — load it from 'Load Draft Sale' while offline."),
+				__("Draft saved offline. Load it from 'Load Draft Sale' while offline."),
 				{ autoClose: 4000 },
 			);
 			return draft;

--- a/frontend/src/components/pos/OpeningDialog.vue
+++ b/frontend/src/components/pos/OpeningDialog.vue
@@ -135,7 +135,7 @@
 				variant="tonal"
 				class="mx-6 mb-2"
 			>
-				{{ __("POS configuration could not be loaded on this device. If you are offline, connect once to load it; if you are online, the server refused the request — check that your account has POS access, then reopen this dialog.") }}
+				{{ __("POS configuration could not be loaded on this device. If you are offline, connect once to load it; if you are online, the server refused the request. Check that your account has POS access, then reopen this dialog.") }}
 			</v-alert>
 			<v-alert
 				v-else-if="config_is_stale"
@@ -515,7 +515,7 @@ export default {
 				if (previous && this.pos_profile !== previous) {
 					toast.warning(
 						this.pos_profile
-							? __("The POS Profile you had selected is no longer available. A different profile has been selected — re-check the opening amounts before submitting.")
+							? __("The POS Profile you had selected is no longer available. A different profile has been selected. Re-check the opening amounts before submitting.")
 							: __("The POS Profile you had selected is no longer available and this company has no other profile. Contact your manager before opening a shift."),
 						{ autoClose: 8000 },
 					);
@@ -721,7 +721,7 @@ export default {
 					if ((outbox.unsyncedOpeningCount ?? 0) >= 3) {
 						this.is_loading = false;
 						toast.error(
-							__("Cannot open another shift offline — 3 shifts are already waiting to sync. Reconnect to clear them first."),
+							__("Cannot open another shift offline: 3 shifts are already waiting to sync. Reconnect to clear them first."),
 							{ autoClose: 7000 },
 						);
 						return;
@@ -799,7 +799,7 @@ export default {
 					this.eventBus.emit("register_pos_data", data);
 					this.eventBus.emit("set_company", data.company);
 					toast.info(
-						__("Shift opened offline — will sync when online."),
+						__("Shift opened offline. It will sync when online."),
 						{ autoClose: 4000 },
 					);
 					this.close_opening_dialog();

--- a/frontend/src/components/pos/Payments.vue
+++ b/frontend/src/components/pos/Payments.vue
@@ -904,13 +904,40 @@ export default {
 			// here and the confirm, the row survives as `pending` and the
 			// startup reconciliation resolves it against the server.
 			// Never let a ledger failure block the sale.
-			const shiftLifecycleId = this.pos_opening_shift?.pospire_lifecycle_id;
+			//
+			// Resolved at sale time rather than trusted off whichever
+			// `pos_opening_shift` object this component currently holds:
+			// `register_pos_profile` has emitters beyond Pos.vue's own stamped
+			// snapshot — App.vue's boot-time bootstrapPosProfileForNavbar, and
+			// Pos.vue's `pos_profile_updated` / `pendingProfileData` replays —
+			// that hand out a live `check_opening_shift` response the server
+			// never echoes `pospire_lifecycle_id` on and that never passes
+			// through `registerShiftLifecycle`. On a common warm-boot ordering
+			// one of those fires last, leaving `pospire_lifecycle_id` undefined
+			// on the object this component ends up holding even though a
+			// stamped durable row exists. `pos_offline_id` is the same id
+			// pre-sync, so it covers an offline-opened shift whose stamp just
+			// hasn't landed on this object; failing that, look the durable row
+			// up by server name — that goes straight to Dexie and is correct
+			// regardless of which transient object is in memory here.
+			let shiftLifecycleId =
+				this.pos_opening_shift?.pospire_lifecycle_id ||
+				this.pos_opening_shift?.pos_offline_id ||
+				null;
+			if (!shiftLifecycleId && this.pos_opening_shift?.name) {
+				try {
+					const { findShiftByServerName } = await import("@/offline/shift-lifecycle");
+					const row = await findShiftByServerName(this.pos_opening_shift.name);
+					shiftLifecycleId = row?.offline_id || null;
+				} catch (err) {
+					console.warn("[Payments] findShiftByServerName failed", err);
+				}
+			}
 			if (!shiftLifecycleId) {
-				// No lifecycle id means an upgrade-day snapshot that predates
-				// the Phase 1 stamp. Skip rather than writing a row keyed to
-				// no shift: it would count toward nothing and could never be
-				// pruned. The close dialog falls back to the Phase 1 outbox
-				// scan for this shift.
+				// No lifecycle id resolvable by any route. Skip rather than
+				// writing a row keyed to no shift: it would count toward
+				// nothing and could never be pruned. The close dialog falls
+				// back to the Phase 1 outbox scan for this shift.
 				console.warn(
 					"[Payments] no shift lifecycle id; skipping contribution staging",
 				);
@@ -924,12 +951,28 @@ export default {
 						cashMode:
 							(this.pos_profile && this.pos_profile.posa_cash_mode_of_payment) ||
 							"Cash",
-						precision: Number(window.sys_defaults?.currency_precision ?? 2),
+						precision: Number(window.sys_defaults?.currency_precision || 2),
 					});
 				} catch (err) {
 					console.warn("[Payments] stageContribution failed", err);
 				}
 			}
+
+			// Un-stage on any failure exit below. `deriveExpectedByMop` sums
+			// pending rows into the shift total, so a row staged ahead of a
+			// submit that never landed would overstate the cashier's expected
+			// figure forever — reconciliation only ever confirms rows the
+			// server has, it never removes ones it doesn't. Safe to call even
+			// when staging was skipped or never ran: deleting a missing key is
+			// a no-op.
+			const discardStagedContribution = async () => {
+				try {
+					const { discardContribution } = await import("@/offline/contribution-ledger");
+					await discardContribution(invoiceOfflineId);
+				} catch (err) {
+					console.warn("[Payments] discardContribution failed", err);
+				}
+			};
 
 			let r = null;
 			try {
@@ -944,6 +987,7 @@ export default {
 					offlineIdempotencyKey: invoiceOfflineId,
 				});
 			} catch (err) {
+				await discardStagedContribution();
 				if (err instanceof OfflineReturnDeferredError) {
 					toast.warning(
 						__("Sales Return requires an online connection in this phase."),
@@ -954,6 +998,7 @@ export default {
 				return;
 			}
 			if (!r) {
+				await discardStagedContribution();
 				toast.error("Error submitting invoice");
 				return;
 			}
@@ -1558,9 +1603,15 @@ export default {
 			});
 			this.eventBus.on("register_pos_profile", (data) => {
 				this.pos_profile = data.pos_profile;
-				// Same object reference Pos.vue/Invoice.vue hold — later
-				// in-place stamps of `pospire_lifecycle_id` (registerShiftLifecycle,
-				// sync ack handlers) stay visible here without a re-emit.
+				// Best-effort only: `register_pos_profile` has emitters (App.vue's
+				// boot-time bootstrapPosProfileForNavbar, Pos.vue's
+				// pos_profile_updated / pendingProfileData replays) that hand out
+				// a live check_opening_shift response never stamped with
+				// pospire_lifecycle_id, and any of them can be the last one to
+				// fire before a sale. submit_invoice does NOT trust this object's
+				// `pospire_lifecycle_id` alone — it falls back to `pos_offline_id`
+				// and then to a durable-row lookup by server name. Kept here only
+				// because pos_profile / cashback / mpesa below still need it.
 				this.pos_opening_shift = data.pos_opening_shift;
 				// Initialize is_cashback based on POS Profile setting
 				// If use_cashback is disabled (0), set is_cashback to false

--- a/frontend/src/components/pos/Payments.vue
+++ b/frontend/src/components/pos/Payments.vue
@@ -722,6 +722,7 @@
 <script>
 import { call } from "@/utils/call";
 import { OfflineReturnDeferredError } from "@/utils/call-registry";
+import { uuidV4 } from "@/offline/db";
 import format from "@/utils/format";
 import hardwareUtils from "@/utils/hardwareUtils";
 import { toast } from "vue3-toastify"; // <-- make sure this is imported
@@ -734,6 +735,7 @@ export default {
 		loading: false,
 		submittingPayment: false,
 		pos_profile: "",
+		pos_opening_shift: "",
 		invoice_doc: "",
 		loyalty_amount: 0,
 		today_date: datetime.now_date(),
@@ -890,6 +892,45 @@ export default {
 			// customer, and substitutes the real name. forceQueue is a no-op
 			// when the registry entry isn't offline-capable.
 			const hasOfflineCustomer = !!this.invoice_doc?.customer_offline_id;
+
+			// One id for the whole sale. `call()` would generate this itself,
+			// but the ledger needs it BEFORE the request so the contribution
+			// can be staged first. Passing it as offlineIdempotencyKey makes
+			// the outbox row, the server's pos_offline_id, and the ledger key
+			// all the same value on both the live and queued paths.
+			const invoiceOfflineId = uuidV4();
+
+			// Stage the contribution before submitting. If the app dies between
+			// here and the confirm, the row survives as `pending` and the
+			// startup reconciliation resolves it against the server.
+			// Never let a ledger failure block the sale.
+			const shiftLifecycleId = this.pos_opening_shift?.pospire_lifecycle_id;
+			if (!shiftLifecycleId) {
+				// No lifecycle id means an upgrade-day snapshot that predates
+				// the Phase 1 stamp. Skip rather than writing a row keyed to
+				// no shift: it would count toward nothing and could never be
+				// pruned. The close dialog falls back to the Phase 1 outbox
+				// scan for this shift.
+				console.warn(
+					"[Payments] no shift lifecycle id; skipping contribution staging",
+				);
+			} else {
+				try {
+					const { stageContribution } = await import("@/offline/contribution-ledger");
+					await stageContribution({
+						invoiceOfflineId,
+						shiftLifecycleId,
+						invoice: this.invoice_doc,
+						cashMode:
+							(this.pos_profile && this.pos_profile.posa_cash_mode_of_payment) ||
+							"Cash",
+						precision: Number(window.sys_defaults?.currency_precision ?? 2),
+					});
+				} catch (err) {
+					console.warn("[Payments] stageContribution failed", err);
+				}
+			}
+
 			let r = null;
 			try {
 				r = await call({
@@ -900,6 +941,7 @@ export default {
 					},
 					intent: "write",
 					forceQueue: hasOfflineCustomer,
+					offlineIdempotencyKey: invoiceOfflineId,
 				});
 			} catch (err) {
 				if (err instanceof OfflineReturnDeferredError) {
@@ -931,6 +973,13 @@ export default {
 				vm.invoice_doc.pospire_pending_sync = true;
 				vm.invoice_doc.pospire_offline_id = r.offline_id;
 
+				try {
+					const { confirmContribution } = await import("@/offline/contribution-ledger");
+					await confirmContribution(invoiceOfflineId);
+				} catch (err) {
+					console.warn("[Payments] confirmContribution failed", err);
+				}
+
 				if (print) {
 					vm.handleProvisionalPrint(vm.invoice_doc);
 				}
@@ -947,6 +996,13 @@ export default {
 				vm.eventBus.emit("clear_invoice", { submitted: true });
 				vm.back_to_invoice();
 				return;
+			}
+
+			try {
+				const { confirmContribution } = await import("@/offline/contribution-ledger");
+				await confirmContribution(invoiceOfflineId);
+			} catch (err) {
+				console.warn("[Payments] confirmContribution failed", err);
 			}
 
 			if (print) {
@@ -1502,6 +1558,10 @@ export default {
 			});
 			this.eventBus.on("register_pos_profile", (data) => {
 				this.pos_profile = data.pos_profile;
+				// Same object reference Pos.vue/Invoice.vue hold — later
+				// in-place stamps of `pospire_lifecycle_id` (registerShiftLifecycle,
+				// sync ack handlers) stay visible here without a re-emit.
+				this.pos_opening_shift = data.pos_opening_shift;
 				// Initialize is_cashback based on POS Profile setting
 				// If use_cashback is disabled (0), set is_cashback to false
 				// If use_cashback is enabled (1), keep it true (default)

--- a/frontend/src/components/pos/Payments.vue
+++ b/frontend/src/components/pos/Payments.vue
@@ -1067,7 +1067,7 @@ export default {
 					vm.pos_profile && vm.pos_profile.use_cashback == 1 ? true : false;
 				vm.sales_person = "";
 				vm.eventBus.emit("set_last_invoice", provisionalName);
-				toast.info(`Queued ${provisionalName} — will sync when online`);
+				toast.info(`Queued ${provisionalName}. Will sync when online`);
 				playSound("submit");
 				vm.addresses = [];
 				vm.invoice_doc = "";

--- a/frontend/src/components/pos/Payments.vue
+++ b/frontend/src/components/pos/Payments.vue
@@ -760,6 +760,44 @@ export default {
 	}),
 
 		methods: {
+			// Run a contribution-ledger operation with a hard deadline.
+			//
+			// Every sale now touches IndexedDB on its critical path, which an
+			// ONLINE sale never did before the ledger existed. Dexie queues
+			// every operation behind `db.open()`, and an open can block
+			// INDEFINITELY rather than fail: a second POS tab still holding the
+			// previous schema version blocks the `version(2)` upgrade until it
+			// closes, and iOS/Safari stall IndexedDB on their own. A promise
+			// that never settles cannot be caught — the awaiting sale would
+			// simply stop, `submittingPayment` would never reset in a `finally`
+			// that never runs, and the Pay button would be dead until reload.
+			// The till must not freeze on a healthy network because of a
+			// bookkeeping write, so a timeout is treated exactly like any other
+			// ledger failure: warn, skip the contribution, sell.
+			async runLedgerOp(label, run) {
+				let timer = null;
+				const TIMEOUT = Symbol("ledger-timeout");
+				try {
+					const outcome = await Promise.race([
+						run(),
+						new Promise((resolve) => {
+							timer = setTimeout(() => resolve(TIMEOUT), 2000);
+						}),
+					]);
+					if (outcome === TIMEOUT) {
+						console.warn(
+							`[Payments] ${label} timed out; contribution skipped`,
+						);
+						return false;
+					}
+					return true;
+				} catch (err) {
+					console.warn(`[Payments] ${label} failed`, err);
+					return false;
+				} finally {
+					if (timer !== null) clearTimeout(timer);
+				}
+			},
 			parseSubmitData(raw) {
 				if (!raw) return {};
 				if (typeof raw === "object") return raw;
@@ -925,13 +963,14 @@ export default {
 				this.pos_opening_shift?.pos_offline_id ||
 				null;
 			if (!shiftLifecycleId && this.pos_opening_shift?.name) {
-				try {
+				// Also deadline-bounded: this is a Dexie read on the same
+				// critical path, with the same never-settles failure mode as
+				// the staging write below.
+				await this.runLedgerOp("findShiftByServerName", async () => {
 					const { findShiftByServerName } = await import("@/offline/shift-lifecycle");
 					const row = await findShiftByServerName(this.pos_opening_shift.name);
 					shiftLifecycleId = row?.offline_id || null;
-				} catch (err) {
-					console.warn("[Payments] findShiftByServerName failed", err);
-				}
+				});
 			}
 			if (!shiftLifecycleId) {
 				// No lifecycle id resolvable by any route. Skip rather than
@@ -942,7 +981,7 @@ export default {
 					"[Payments] no shift lifecycle id; skipping contribution staging",
 				);
 			} else {
-				try {
+				await this.runLedgerOp("stageContribution", async () => {
 					const { stageContribution } = await import("@/offline/contribution-ledger");
 					await stageContribution({
 						invoiceOfflineId,
@@ -953,9 +992,7 @@ export default {
 							"Cash",
 						precision: Number(window.sys_defaults?.currency_precision || 2),
 					});
-				} catch (err) {
-					console.warn("[Payments] stageContribution failed", err);
-				}
+				});
 			}
 
 			// Un-stage on any failure exit below. `deriveExpectedByMop` sums
@@ -966,12 +1003,10 @@ export default {
 			// when staging was skipped or never ran: deleting a missing key is
 			// a no-op.
 			const discardStagedContribution = async () => {
-				try {
+				await this.runLedgerOp("discardContribution", async () => {
 					const { discardContribution } = await import("@/offline/contribution-ledger");
 					await discardContribution(invoiceOfflineId);
-				} catch (err) {
-					console.warn("[Payments] discardContribution failed", err);
-				}
+				});
 			};
 
 			let r = null;
@@ -1018,12 +1053,10 @@ export default {
 				vm.invoice_doc.pospire_pending_sync = true;
 				vm.invoice_doc.pospire_offline_id = r.offline_id;
 
-				try {
+				await vm.runLedgerOp("confirmContribution", async () => {
 					const { confirmContribution } = await import("@/offline/contribution-ledger");
 					await confirmContribution(invoiceOfflineId);
-				} catch (err) {
-					console.warn("[Payments] confirmContribution failed", err);
-				}
+				});
 
 				if (print) {
 					vm.handleProvisionalPrint(vm.invoice_doc);
@@ -1043,12 +1076,10 @@ export default {
 				return;
 			}
 
-			try {
+			await vm.runLedgerOp("confirmContribution", async () => {
 				const { confirmContribution } = await import("@/offline/contribution-ledger");
 				await confirmContribution(invoiceOfflineId);
-			} catch (err) {
-				console.warn("[Payments] confirmContribution failed", err);
-			}
+			});
 
 			if (print) {
 				vm.handlePrint(vm.invoice_doc.name);

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -1291,6 +1291,19 @@ export default {
 						}
 						if (!resolved) return;
 
+						// The close has landed server-side, so this shift's
+						// contributions can go. Deliberately NOT done at close
+						// time: a queued close can sit unsynced for hours and
+						// the dialog may be reopened in the meantime.
+						try {
+							const { deleteContributionsForShift } = await import(
+								"@/offline/contribution-ledger"
+							);
+							await deleteContributionsForShift(resolved.shiftLifecycleId);
+						} catch (err) {
+							console.warn("[Pos] contribution prune failed", err);
+						}
+
 						if (this.pendingClosingOfflineId === event.offline_id) {
 							this.pendingClosingOfflineId = null;
 						}

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -574,36 +574,72 @@ export default {
 			// the server keeps full precision.
 			const precision = window.sys_defaults?.currency_precision || 2;
 
-			// Stopgap — offline-queued sales only. Does NOT recover takings
-			// from earlier in the shift while online; that needs the Phase 2
-			// contribution ledger. The dialog labels the result provisional
-			// precisely because of this gap.
+			// Phase 2: totals come from the contribution ledger, which
+			// records EVERY sale — online and offline — so the figure is no
+			// longer missing the pre-outage takings.
+			//
+			// Resolve the lifecycle id with the SAME fallback chain
+			// Payments.vue's submit_invoice and reconcileContributions use,
+			// so this reads the same row the sales were staged against. NOT
+			// `this.shiftLifecycleId` — `applyOpeningSnapshot` nulls it
+			// synchronously before the un-awaited `registerShiftLifecycle`
+			// can re-stamp it, so it can read `null` here even though a
+			// durable row exists.
+			let lifecycleId =
+				opening.pospire_lifecycle_id || opening.pos_offline_id || null;
+			if (!lifecycleId && opening.name) {
+				try {
+					const { findShiftByServerName } = await import(
+						"@/offline/shift-lifecycle"
+					);
+					const row = await findShiftByServerName(opening.name);
+					lifecycleId = row?.offline_id || null;
+				} catch (err) {
+					console.warn("[Pos] findShiftByServerName failed", err);
+				}
+			}
+
+			// Fall back to the Phase 1 outbox scan when no lifecycle id is
+			// resolvable at all (an upgrade-day snapshot predating the
+			// stamp). An offline-only figure is worse than the ledger's but
+			// far better than a blank one.
 			let queued = { byMop: {}, uncertainCount: 0 };
 			try {
-				const { sumQueuedPaymentsByMop } = await import(
-					"@/offline/shift-lifecycle"
-				);
-				// BOTH anchors, always — sumQueuedPaymentsByMop matches on
-				// either. A shift opened offline and synced mid-shift has
-				// invoices on both sides of the sync: the pre-sync ones are
-				// stamped with `shift_offline_id` (= the lifecycle id, since
-				// the row is keyed by the opening's outbox id) and the
-				// post-sync ones carry only the server name. Passing just one
-				// anchor dropped a whole half of the shift's takings.
-				// `pospire_lifecycle_id` is the offline id's stand-in after the
-				// sync handler clears `pos_offline_id`; on an online-opened
-				// shift it is a UUID no outbox row carries, which simply
-				// matches nothing and leaves the server-name clause to do the
-				// work.
-				queued = await sumQueuedPaymentsByMop({
-					openingServerName: opening.name || null,
-					shiftOfflineId:
-						opening.pos_offline_id || opening.pospire_lifecycle_id || null,
-					cashMode,
-					precision,
-				});
+				if (lifecycleId) {
+					const { deriveExpectedByMop } = await import(
+						"@/offline/contribution-ledger"
+					);
+					const derived = await deriveExpectedByMop(lifecycleId, precision);
+					queued = {
+						byMop: derived.byMop,
+						uncertainCount: derived.pendingCount,
+					};
+				} else {
+					const { sumQueuedPaymentsByMop } = await import(
+						"@/offline/shift-lifecycle"
+					);
+					// BOTH anchors, always — sumQueuedPaymentsByMop matches on
+					// either. A shift opened offline and synced mid-shift has
+					// invoices on both sides of the sync: the pre-sync ones are
+					// stamped with `shift_offline_id` (= the lifecycle id, since
+					// the row is keyed by the opening's outbox id) and the
+					// post-sync ones carry only the server name. Passing just one
+					// anchor dropped a whole half of the shift's takings.
+					// `pospire_lifecycle_id` is the offline id's stand-in after the
+					// sync handler clears `pos_offline_id`; on an online-opened
+					// shift it is a UUID no outbox row carries, which simply
+					// matches nothing and leaves the server-name clause to do the
+					// work.
+					queued = await sumQueuedPaymentsByMop({
+						openingServerName: opening.name || null,
+						shiftOfflineId:
+							opening.pos_offline_id || opening.pospire_lifecycle_id || null,
+						cashMode,
+						precision,
+					});
+				}
 			} catch (err) {
-				console.warn("[Pos] queued payment sum failed", err);
+				console.warn("[Pos] expected-amount derivation failed", err);
 			}
 
 			const seen = new Set();

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -612,6 +612,17 @@ export default {
 							import("@/offline/shift-lifecycle"),
 						]);
 					const derived = await deriveExpectedByMop(lifecycleId, precision);
+					// Assign from the ledger FIRST, before the scan even runs.
+					// `contributionForInvoice`/`resolveChangeAmount` (which the
+					// scan below calls per row) are unguarded on payload shape —
+					// unlike `listInvoiceRowsAcrossStatuses`, which is
+					// deliberately written so one poison row cannot "silently
+					// zero the cashier's entire expected-amount figure". A scan
+					// throw below must therefore only cost the gap-detection and
+					// needs_review count, never the ledger figure already
+					// computed here.
+					queued = { byMop: derived.byMop, uncertainCount: derived.pendingCount };
+
 					// Run the Phase 1 scan alongside the ledger EVEN THOUGH an id
 					// resolved. Two live cases need it:
 					//  - Upgrade day: a shift stamped with a lifecycle id but
@@ -623,16 +634,35 @@ export default {
 					//    lifecycle id at sale time) or `stageContribution` threw
 					//    is invisible to the ledger forever, but the scan still
 					//    catches it if it was queued.
-					const scan = await sumQueuedPaymentsByMop({
-						openingServerName: opening.name || null,
-						shiftOfflineId: lifecycleId,
-						cashMode,
-						precision,
-					});
+					// Wrapped in its own try/catch — see the comment above
+					// `queued`'s assignment: a scan failure must not undo it.
+					let scan = { byMop: {}, uncertainCount: 0 };
+					try {
+						scan = await sumQueuedPaymentsByMop({
+							openingServerName: opening.name || null,
+							shiftOfflineId: lifecycleId,
+							cashMode,
+							precision,
+						});
+					} catch (err) {
+						console.warn(
+							"[Pos] outbox scan failed; gap-detection and needs_review count skipped",
+							err,
+						);
+					}
+
 					if (Object.keys(derived.byMop).length === 0) {
 						// Ledger has nothing for this shift — the upgrade-day
-						// case. The scan is all there is; use it outright.
-						queued = { byMop: scan.byMop, uncertainCount: scan.uncertainCount };
+						// case. The scan is all there is; use it outright. Still
+						// carry `derived.pendingCount`: a staged-but-unconfirmed
+						// contribution can have an empty `by_mop` (a zero-payment
+						// or fully loyalty-funded invoice), which would otherwise
+						// be silently dropped here even though something is
+						// genuinely still pending.
+						queued = {
+							byMop: scan.byMop,
+							uncertainCount: scan.uncertainCount + derived.pendingCount,
+						};
 					} else {
 						// The ledger has SOME data. Deliberately not merged with
 						// the scan: the scan only sees QUEUED sales while the
@@ -640,11 +670,12 @@ export default {
 						// (double-counts anything already in both) nor taking a
 						// per-MOP max is correct in general — either risks
 						// mis-stating the figure a cashier signs off on. Instead,
-						// trust the ledger's total but use the scan to DETECT a
-						// shortfall: any MOP where the scan reports more than the
-						// ledger is evidence the ledger is missing a sale for
-						// that MOP, so fold it into the uncertainty count rather
-						// than silently trusting either source.
+						// trust the ledger's total (already assigned above) but
+						// use the scan to DETECT a shortfall: any MOP where the
+						// scan reports more than the ledger is evidence the
+						// ledger is missing a sale for that MOP, so fold it into
+						// the uncertainty count rather than silently trusting
+						// either source.
 						let gapCount = 0;
 						for (const [mop, amount] of Object.entries(scan.byMop)) {
 							if (amount > (derived.byMop[mop] ?? 0)) gapCount += 1;

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -269,6 +269,55 @@ export default {
 			}
 		},
 
+		/**
+		 * Reconciliation-path contribution prune — DISTINCT from the live
+		 * `onSynced` `closing_entry` prune further below. Do NOT fold these
+		 * two into one: they cover different windows.
+		 *
+		 * A closing can land in `released` here WITHOUT `onSynced` ever
+		 * having fired for it, because that live callback needs a
+		 * subscriber running at the moment the sync happens:
+		 *   - the `onSynced` prune itself threw (it is warn-only and does
+		 *     not retry, so the row would otherwise survive forever);
+		 *   - another tab drained the outbox while this tab was on a
+		 *     different route and `Pos.vue` was unmounted;
+		 *   - the outbox row was vacuumed to a tombstone before this tab
+		 *     observed the sync.
+		 * In every one of those, this reconciliation pass is the ONLY
+		 * remaining place that ever learns the closing landed, so it must
+		 * carry its own prune rather than relying on `onSynced` to have
+		 * already done it.
+		 *
+		 * `deleteContributionsForShift` is idempotent (deletes are a no-op
+		 * on an already-empty shift), so this and the `onSynced` prune can
+		 * never conflict — the common case prunes once via `onSynced` and
+		 * this call simply finds nothing left to do on the next boot.
+		 *
+		 * `released` ONLY, same as `dropSnapshotForReleasedShifts` — never
+		 * `reopened`. A reopened shift's closing was voided, so the shift
+		 * is still sellable and its takings must still be there.
+		 *
+		 * Fire-and-forget by design: called without `await` from the
+		 * reconciliation chain, which must boot the POS regardless of
+		 * whether pruning succeeds. Failure is caught here and only
+		 * warned — it must never reject into that chain.
+		 */
+		pruneReleasedShiftContributions(releasedIds) {
+			if (!Array.isArray(releasedIds) || !releasedIds.length) return;
+			import("@/offline/contribution-ledger")
+				.then(({ deleteContributionsForShift }) =>
+					Promise.all(
+						releasedIds.map((id) => deleteContributionsForShift(id)),
+					),
+				)
+				.catch((err) => {
+					console.warn(
+						"[Pos] reconciliation contribution prune failed",
+						err,
+					);
+				});
+		},
+
 		openingSnapshotDiffers(cached, live) {
 			if (!cached) return true;
 			if (
@@ -1084,6 +1133,11 @@ export default {
 					// what used to strand them in the opening dialog and get a
 					// second shift opened against the first.
 					this.dropSnapshotForReleasedShifts(result?.released);
+					// Reconciliation-path contribution prune (see the method's
+					// doc comment). Deliberately NOT awaited: this whole chain
+					// exists to unblock `check_opening_entry()` in `.finally`
+					// below, and pruning must never delay or fail that boot.
+					this.pruneReleasedShiftContributions(result?.released);
 				})
 				.catch((err) => {
 					console.warn("[Pos] pending-closure reconciliation failed", err);
@@ -1295,6 +1349,14 @@ export default {
 						// contributions can go. Deliberately NOT done at close
 						// time: a queued close can sit unsynced for hours and
 						// the dialog may be reopened in the meantime.
+						//
+						// LIVE-SYNC prune — DISTINCT from the reconciliation-path
+						// prune in `pruneReleasedShiftContributions` (called from
+						// the `mounted` reconciliation chain). Do NOT merge these
+						// two: this one only ever fires while a subscriber is
+						// running at the moment the sync happens (see that
+						// method's doc comment for the cases it misses and why
+						// the other hook exists to catch them).
 						try {
 							const { deleteContributionsForShift } = await import(
 								"@/offline/contribution-ledger"

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -303,6 +303,11 @@ export default {
 			// online-opened ones included. Fire-and-forget: a Dexie failure
 			// must never block the POS from loading.
 			this.registerShiftLifecycle(snapshot);
+			// Resolve any contribution left `pending` by a crash between the
+			// stage and the confirm. Fire-and-forget: nothing during boot reads
+			// this, and a failure just leaves rows pending, which still count
+			// toward the displayed total.
+			this.reconcileContributions(snapshot);
 			this.get_offers(this.pos_profile.name);
 			this.eventBus.emit("register_pos_profile", snapshot);
 			this.eventBus.emit("set_company", snapshot.company);
@@ -432,6 +437,59 @@ export default {
 				}
 			} catch (err) {
 				console.warn("[Pos] registerShiftLifecycle failed", err);
+			}
+		},
+		/**
+		 * Resolve contributions left `pending` by a crash between staging and
+		 * confirming (see contribution-ledger.ts). Fire-and-forget and
+		 * non-fatal by construction: nothing during boot depends on this
+		 * having run, so it must never delay or throw into
+		 * `check_opening_entry`.
+		 *
+		 * Needs the shift's lifecycle id BEFORE `registerShiftLifecycle` (also
+		 * fired above, also un-awaited) has necessarily stamped it anywhere:
+		 * `this.shiftLifecycleId` was just nulled out synchronously by
+		 * `applyOpeningSnapshot` and is only reassigned once
+		 * `registerShiftLifecycle`'s internal awaits resolve, which can
+		 * happen after this method's own synchronous portion has already run.
+		 * So this uses the same per-sale fallback chain Payments.vue uses
+		 * rather than trusting `this.shiftLifecycleId` or
+		 * `pospire_lifecycle_id` alone: the in-memory stamp, then the
+		 * pre-sync offline id, then a direct Dexie lookup by server name. A
+		 * brand-new shift (nothing to reconcile yet) can race
+		 * `registerShiftLifecycle`'s write of the durable row, but a resumed
+		 * shift's row was already written in an earlier session, so the
+		 * lookup that matters in practice never races it.
+		 */
+		async reconcileContributions(snapshot) {
+			const shift = snapshot?.pos_opening_shift;
+			if (!shift) return;
+			try {
+				let shiftLifecycleId =
+					shift.pospire_lifecycle_id || shift.pos_offline_id || null;
+				if (!shiftLifecycleId && shift.name) {
+					const { findShiftByServerName } = await import(
+						"@/offline/shift-lifecycle"
+					);
+					const row = await findShiftByServerName(shift.name);
+					shiftLifecycleId = row?.offline_id || null;
+				}
+				if (!shiftLifecycleId) return;
+				const { reconcilePendingContributions } = await import(
+					"@/offline/contribution-ledger"
+				);
+				await reconcilePendingContributions({
+					shiftLifecycleId,
+					// Same `pospire_pending_sync` discriminator registerShiftLifecycle
+					// uses: `pos_offline_id` is a persisted server field that
+					// survives sync, so it cannot tell "unsynced" from "synced".
+					openingServerName: shift.pospire_pending_sync
+						? null
+						: shift.name || null,
+					openingOfflineId: shift.pos_offline_id || null,
+				});
+			} catch (err) {
+				console.warn("[Pos] reconcileContributions failed", err);
 			}
 		},
 		/**

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -606,34 +606,76 @@ export default {
 			let queued = { byMop: {}, uncertainCount: 0 };
 			try {
 				if (lifecycleId) {
-					const { deriveExpectedByMop } = await import(
-						"@/offline/contribution-ledger"
-					);
+					const [{ deriveExpectedByMop }, { sumQueuedPaymentsByMop }] =
+						await Promise.all([
+							import("@/offline/contribution-ledger"),
+							import("@/offline/shift-lifecycle"),
+						]);
 					const derived = await deriveExpectedByMop(lifecycleId, precision);
-					queued = {
-						byMop: derived.byMop,
-						uncertainCount: derived.pendingCount,
-					};
+					// Run the Phase 1 scan alongside the ledger EVEN THOUGH an id
+					// resolved. Two live cases need it:
+					//  - Upgrade day: a shift stamped with a lifecycle id but
+					//    opened before Phase 2 shipped has queued sales and NO
+					//    contributions at all. Branching only on "did an id
+					//    resolve" left this case showing opening amounts only —
+					//    strictly worse than the Phase 1 stopgap it replaced.
+					//  - A permanent gap: a sale where staging was skipped (no
+					//    lifecycle id at sale time) or `stageContribution` threw
+					//    is invisible to the ledger forever, but the scan still
+					//    catches it if it was queued.
+					const scan = await sumQueuedPaymentsByMop({
+						openingServerName: opening.name || null,
+						shiftOfflineId: lifecycleId,
+						cashMode,
+						precision,
+					});
+					if (Object.keys(derived.byMop).length === 0) {
+						// Ledger has nothing for this shift — the upgrade-day
+						// case. The scan is all there is; use it outright.
+						queued = { byMop: scan.byMop, uncertainCount: scan.uncertainCount };
+					} else {
+						// The ledger has SOME data. Deliberately not merged with
+						// the scan: the scan only sees QUEUED sales while the
+						// ledger sees every sale, so neither summing the two
+						// (double-counts anything already in both) nor taking a
+						// per-MOP max is correct in general — either risks
+						// mis-stating the figure a cashier signs off on. Instead,
+						// trust the ledger's total but use the scan to DETECT a
+						// shortfall: any MOP where the scan reports more than the
+						// ledger is evidence the ledger is missing a sale for
+						// that MOP, so fold it into the uncertainty count rather
+						// than silently trusting either source.
+						let gapCount = 0;
+						for (const [mop, amount] of Object.entries(scan.byMop)) {
+							if (amount > (derived.byMop[mop] ?? 0)) gapCount += 1;
+						}
+						queued = {
+							byMop: derived.byMop,
+							// Combine every signal the ledger's own pendingCount
+							// misses: contributions still pending (stage/confirm
+							// not resolved) PLUS outbox invoices this shift has
+							// in needs_review/handed_off (server rejected or
+							// handed the sale off) PLUS any detected shortfall
+							// above. `confirmContribution` fires on the enqueue
+							// ack, before either of those outbox outcomes is
+							// known, so a later-rejected sale stays "confirmed"
+							// and would otherwise raise no flag at all.
+							uncertainCount:
+								derived.pendingCount + scan.uncertainCount + gapCount,
+						};
+					}
 				} else {
 					const { sumQueuedPaymentsByMop } = await import(
 						"@/offline/shift-lifecycle"
 					);
-					// BOTH anchors, always — sumQueuedPaymentsByMop matches on
-					// either. A shift opened offline and synced mid-shift has
-					// invoices on both sides of the sync: the pre-sync ones are
-					// stamped with `shift_offline_id` (= the lifecycle id, since
-					// the row is keyed by the opening's outbox id) and the
-					// post-sync ones carry only the server name. Passing just one
-					// anchor dropped a whole half of the shift's takings.
-					// `pospire_lifecycle_id` is the offline id's stand-in after the
-					// sync handler clears `pos_offline_id`; on an online-opened
-					// shift it is a UUID no outbox row carries, which simply
-					// matches nothing and leaves the server-name clause to do the
-					// work.
 					queued = await sumQueuedPaymentsByMop({
 						openingServerName: opening.name || null,
-						shiftOfflineId:
-							opening.pos_offline_id || opening.pospire_lifecycle_id || null,
+						// The two fields `lifecycleId` above is derived from
+						// (`pospire_lifecycle_id`, `pos_offline_id`) are both
+						// already known falsy by the time this branch is
+						// reachable — that's what made `lifecycleId` null — so
+						// there is nothing left to pass here.
+						shiftOfflineId: null,
 						cashMode,
 						precision,
 					});

--- a/frontend/src/components/pos/Pos.vue
+++ b/frontend/src/components/pos/Pos.vue
@@ -651,26 +651,43 @@ export default {
 			// Fall back to the Phase 1 outbox scan when no lifecycle id is
 			// resolvable at all (an upgrade-day snapshot predating the
 			// stamp). An offline-only figure is worse than the ledger's but
-			// far better than a blank one.
+			// far better than a blank one. The banner wording differs between
+			// the two — only the scan branch is blind to online sales — so the
+			// stub carries a discriminator, not just `pospire_offline_stub`.
 			let queued = { byMop: {}, uncertainCount: 0 };
+			let source = "scan";
 			try {
 				if (lifecycleId) {
-					const [{ deriveExpectedByMop }, { sumQueuedPaymentsByMop }] =
-						await Promise.all([
-							import("@/offline/contribution-ledger"),
-							import("@/offline/shift-lifecycle"),
-						]);
+					const [
+						{ deriveExpectedByMop },
+						{ scanQueuedContributionsByInvoice },
+					] = await Promise.all([
+						import("@/offline/contribution-ledger"),
+						import("@/offline/shift-lifecycle"),
+					]);
 					const derived = await deriveExpectedByMop(lifecycleId, precision);
+					// Keyed off whether the ledger actually HAS rows, not off
+					// whether an id resolved. An upgrade-day shift resolves an id
+					// but has no contributions at all, and its figure then comes
+					// entirely from the outbox — which is blind to online sales,
+					// so the Phase 1 caveat is still the truthful banner there.
+					if (derived.offlineIds.length > 0) source = "ledger";
 					// Assign from the ledger FIRST, before the scan even runs.
 					// `contributionForInvoice`/`resolveChangeAmount` (which the
 					// scan below calls per row) are unguarded on payload shape —
 					// unlike `listInvoiceRowsAcrossStatuses`, which is
 					// deliberately written so one poison row cannot "silently
 					// zero the cashier's entire expected-amount figure". A scan
-					// throw below must therefore only cost the gap-detection and
-					// needs_review count, never the ledger figure already
-					// computed here.
-					queued = { byMop: derived.byMop, uncertainCount: derived.pendingCount };
+					// throw below must therefore only cost the outbox-side
+					// additions, never the ledger figure already computed here.
+					queued = {
+						byMop: derived.byMop,
+						// `skippedCount` is money that DECRYPTED NOWHERE: an
+						// undecryptable row's amount is simply absent from
+						// `byMop`, so without this the dialog would show a short
+						// number with no hint that anything went missing.
+						uncertainCount: derived.pendingCount + derived.skippedCount,
+					};
 
 					// Run the Phase 1 scan alongside the ledger EVEN THOUGH an id
 					// resolved. Two live cases need it:
@@ -680,14 +697,15 @@ export default {
 					//    resolve" left this case showing opening amounts only —
 					//    strictly worse than the Phase 1 stopgap it replaced.
 					//  - A permanent gap: a sale where staging was skipped (no
-					//    lifecycle id at sale time) or `stageContribution` threw
-					//    is invisible to the ledger forever, but the scan still
-					//    catches it if it was queued.
+					//    lifecycle id at sale time, Dexie in safe mode, the
+					//    staging timeout in Payments.vue firing) is invisible to
+					//    the ledger forever, but the scan still catches it if it
+					//    was queued.
 					// Wrapped in its own try/catch — see the comment above
 					// `queued`'s assignment: a scan failure must not undo it.
-					let scan = { byMop: {}, uncertainCount: 0 };
+					let scan = { byMop: {}, uncertainCount: 0, byInvoice: new Map() };
 					try {
-						scan = await sumQueuedPaymentsByMop({
+						scan = await scanQueuedContributionsByInvoice({
 							openingServerName: opening.name || null,
 							shiftOfflineId: lifecycleId,
 							cashMode,
@@ -695,55 +713,56 @@ export default {
 						});
 					} catch (err) {
 						console.warn(
-							"[Pos] outbox scan failed; gap-detection and needs_review count skipped",
+							"[Pos] outbox scan failed; queued-only sales may be missing from the figure",
 							err,
 						);
 					}
 
-					if (Object.keys(derived.byMop).length === 0) {
-						// Ledger has nothing for this shift — the upgrade-day
-						// case. The scan is all there is; use it outright. Still
-						// carry `derived.pendingCount`: a staged-but-unconfirmed
-						// contribution can have an empty `by_mop` (a zero-payment
-						// or fully loyalty-funded invoice), which would otherwise
-						// be silently dropped here even though something is
-						// genuinely still pending.
-						queued = {
-							byMop: scan.byMop,
-							uncertainCount: scan.uncertainCount + derived.pendingCount,
-						};
-					} else {
-						// The ledger has SOME data. Deliberately not merged with
-						// the scan: the scan only sees QUEUED sales while the
-						// ledger sees every sale, so neither summing the two
-						// (double-counts anything already in both) nor taking a
-						// per-MOP max is correct in general — either risks
-						// mis-stating the figure a cashier signs off on. Instead,
-						// trust the ledger's total (already assigned above) but
-						// use the scan to DETECT a shortfall: any MOP where the
-						// scan reports more than the ledger is evidence the
-						// ledger is missing a sale for that MOP, so fold it into
-						// the uncertainty count rather than silently trusting
-						// either source.
-						let gapCount = 0;
-						for (const [mop, amount] of Object.entries(scan.byMop)) {
-							if (amount > (derived.byMop[mop] ?? 0)) gapCount += 1;
+					// UNION the two stores, per invoice. Both key on the same
+					// invoice `offline_id` (`call()` passes it as
+					// `offlineIdempotencyKey`; `enqueue` stores it verbatim), so
+					// "in the ledger" and "in the outbox" is an exact test and
+					// the union is exactly computable: every ledger contribution,
+					// PLUS every outbox invoice the ledger never saw.
+					//
+					// Earlier revisions computed the scan and then threw its
+					// money away, folding it into a bare count. That understated
+					// the drawer by the full value of any sale whose staging was
+					// skipped — on upgrade day, by the whole pre-upgrade shift.
+					// Neither store is a superset of the other (the scan can't
+					// see online sales; the ledger can't see sales staged before
+					// it existed or when staging was skipped), so taking either
+					// one alone is wrong.
+					const ledgerIds = new Set(derived.offlineIds);
+					const byMop = { ...derived.byMop };
+					const f = 10 ** precision;
+					let gapCount = 0;
+					for (const [offlineId, contribution] of scan.byInvoice) {
+						if (ledgerIds.has(offlineId)) continue; // already counted — never twice.
+						gapCount += 1;
+						for (const [mop, amount] of Object.entries(contribution)) {
+							byMop[mop] =
+								Math.round(((byMop[mop] || 0) + amount) * f) / f;
 						}
-						queued = {
-							byMop: derived.byMop,
-							// Combine every signal the ledger's own pendingCount
-							// misses: contributions still pending (stage/confirm
-							// not resolved) PLUS outbox invoices this shift has
-							// in needs_review/handed_off (server rejected or
-							// handed the sale off) PLUS any detected shortfall
-							// above. `confirmContribution` fires on the enqueue
-							// ack, before either of those outbox outcomes is
-							// known, so a later-rejected sale stays "confirmed"
-							// and would otherwise raise no flag at all.
-							uncertainCount:
-								derived.pendingCount + scan.uncertainCount + gapCount,
-						};
 					}
+					queued = {
+						byMop,
+						// Combine every signal the ledger's own pendingCount
+						// misses: contributions still pending (stage/confirm not
+						// resolved) PLUS rows that would not decrypt PLUS outbox
+						// invoices this shift has in needs_review/handed_off
+						// (server rejected or handed the sale off) PLUS the
+						// invoices the ledger never recorded at all.
+						// `confirmContribution` fires on the enqueue ack, before
+						// either outbox outcome is known, so a later-rejected
+						// sale stays "confirmed" and would otherwise raise no
+						// flag at all.
+						uncertainCount:
+							derived.pendingCount +
+							derived.skippedCount +
+							scan.uncertainCount +
+							gapCount,
+					};
 				} else {
 					const { sumQueuedPaymentsByMop } = await import(
 						"@/offline/shift-lifecycle"
@@ -808,6 +827,11 @@ export default {
 				denomination_details: opening.denomination_details || [],
 				pospire_offline_stub: true,
 				pospire_uncertain_count: queued.uncertainCount,
+				// "ledger" | "scan" — which store the expected amounts came
+				// from. The dialog needs it because only the scan branch is
+				// structurally blind to sales made earlier while ONLINE, and
+				// that caveat must not be shown when it is false.
+				pospire_source: source,
 			};
 		},
 		async submit_closing_pos(data) {

--- a/frontend/src/components/pos/UpdateCustomer.vue
+++ b/frontend/src/components/pos/UpdateCustomer.vue
@@ -512,7 +512,7 @@ export default {
 					}
 
 					toast.info(
-						__("Customer queued offline — will sync when online."),
+						__("Customer queued offline. It will sync when online."),
 						{ autoClose: 3000 },
 					);
 					playSound("submit");

--- a/frontend/src/components/pos/UpdateCustomer.vue
+++ b/frontend/src/components/pos/UpdateCustomer.vue
@@ -501,7 +501,7 @@ export default {
 							// concrete handle.
 							toast.error(
 								__(
-									"Customer create failed AND rollback failed — local storage may be unhealthy. Contact support; reference offline_id {0}.",
+									"Customer create failed AND rollback failed. Local storage may be unhealthy. Contact support; reference offline_id {0}.",
 									[r.offline_id],
 								),
 								{ autoClose: 8000 },

--- a/frontend/src/offline/contribution-ledger.ts
+++ b/frontend/src/offline/contribution-ledger.ts
@@ -15,9 +15,9 @@
 import {
 	buildStoredContribution,
 	deleteContributionsForShift,
-	getContribution,
+	getStoredContribution,
 	listContributionsForShift,
-	listPendingContributions,
+	listPendingContributionsForShift,
 	markContributionConfirmed,
 	putContribution,
 } from "./repos/contributions";
@@ -46,7 +46,12 @@ export async function stageContribution(
 		input.cashMode,
 		input.precision,
 	);
-	const existing = await getContribution(input.invoiceOfflineId);
+	// The STORED row, deliberately not decrypted: only the plaintext scalars
+	// below are read. Decrypting here would make an unreadable envelope throw
+	// on the one path that can repair it — the `put` below overwrites the
+	// corrupt row with a fresh, readable one — and because staging happens
+	// BEFORE the submit, that throw would hard-block the sale itself.
+	const existing = await getStoredContribution(input.invoiceOfflineId);
 	const row: ContributionRow = {
 		offline_id: input.invoiceOfflineId,
 		shift_lifecycle_id: input.shiftLifecycleId,
@@ -108,12 +113,18 @@ export async function deriveExpectedByMop(
  * The oracle is `offline.get_shift_invoice_offline_ids`, which returns
  * `pos_offline_id` for every submitted Sales Invoice on the shift — and both
  * submit paths persist that id, so it covers live and queued sales alike.
+ *
+ * Both the input and the result are scoped to `shiftLifecycleId`, because the
+ * oracle is scoped to one opening: rows from another shift can never appear in
+ * its answer, so including them would strand them in `stillPending` at every
+ * startup and misreport them as this shift's unconfirmed money.
  */
 export async function reconcilePendingContributions(opts: {
+	shiftLifecycleId: string;
 	openingServerName: string | null;
 	openingOfflineId: string | null;
 }): Promise<{ confirmed: string[]; stillPending: string[] }> {
-	const pending = await listPendingContributions();
+	const pending = await listPendingContributionsForShift(opts.shiftLifecycleId);
 	if (!pending.length) return { confirmed: [], stillPending: [] };
 	if (!opts.openingServerName && !opts.openingOfflineId) {
 		return { confirmed: [], stillPending: pending.map((r) => r.offline_id) };

--- a/frontend/src/offline/contribution-ledger.ts
+++ b/frontend/src/offline/contribution-ledger.ts
@@ -14,6 +14,7 @@
 
 import {
 	buildStoredContribution,
+	deleteContribution,
 	deleteContributionsForShift,
 	getStoredContribution,
 	listContributionsForShift,
@@ -73,6 +74,23 @@ export async function confirmContribution(
 	invoiceOfflineId: string,
 ): Promise<void> {
 	await markContributionConfirmed(invoiceOfflineId, Date.now());
+}
+
+/**
+ * Un-stage a contribution for a sale that never landed. `deriveExpectedByMop`
+ * sums pending rows into the shift total (deliberately — cash physically
+ * taken counts even before sync), so a row staged ahead of a submit that then
+ * failed (4xx validation, a deferred return, any other error exit) would
+ * overstate the figure the cashier signs off on forever: reconciliation only
+ * ever confirms rows the server has, it never removes ones it doesn't. Call
+ * this on every failure exit after `stageContribution` ran. Safe to call on a
+ * row that was never staged (or already removed) — deleting a missing key is
+ * a no-op.
+ */
+export async function discardContribution(
+	invoiceOfflineId: string,
+): Promise<void> {
+	await deleteContribution(invoiceOfflineId);
 }
 
 export interface DerivedExpected {

--- a/frontend/src/offline/contribution-ledger.ts
+++ b/frontend/src/offline/contribution-ledger.ts
@@ -1,0 +1,157 @@
+/**
+ * Contribution ledger.
+ *
+ * One row per invoice, keyed by the invoice's `offline_id`. Written on BOTH
+ * submit paths: `call()` injects that same id into the live request args
+ * (call.ts) and the live endpoint persists it (posapp.py), so an online sale
+ * and an offline one are recorded identically.
+ *
+ * The shift total is DERIVED by recomputing over unique contributions, never
+ * accumulated. A crash between staging and confirming leaves a recoverable
+ * `pending` row; a retry overwrites its own row rather than adding a second.
+ * That is what makes this safe for a figure a cashier signs off.
+ */
+
+import {
+	buildStoredContribution,
+	deleteContributionsForShift,
+	getContribution,
+	listContributionsForShift,
+	listPendingContributions,
+	markContributionConfirmed,
+	putContribution,
+} from "./repos/contributions";
+import { contributionForInvoice } from "./shift-lifecycle";
+import type { ContributionRow } from "./types";
+
+export interface ContributionInput {
+	invoiceOfflineId: string;
+	shiftLifecycleId: string;
+	/** The invoice doc as it will be submitted. */
+	invoice: Record<string, unknown>;
+	cashMode: string;
+	precision: number;
+}
+
+/**
+ * Record an invoice's contribution as `pending`, BEFORE the submit is
+ * attempted. Overwrites any existing row for the same invoice, so a retry is
+ * idempotent by construction.
+ */
+export async function stageContribution(
+	input: ContributionInput,
+): Promise<void> {
+	const byMop = contributionForInvoice(
+		input.invoice,
+		input.cashMode,
+		input.precision,
+	);
+	const existing = await getContribution(input.invoiceOfflineId);
+	const row: ContributionRow = {
+		offline_id: input.invoiceOfflineId,
+		shift_lifecycle_id: input.shiftLifecycleId,
+		// A re-stage of an already-confirmed invoice keeps its confirmed
+		// status — the money landed, and demoting it would make the startup
+		// reconciliation re-ask the server about a settled sale.
+		status: existing?.status === "confirmed" ? "confirmed" : "pending",
+		by_mop: byMop,
+		created_at: existing?.created_at ?? Date.now(),
+		confirmed_at: existing?.confirmed_at ?? null,
+	};
+	// Encrypt OUTSIDE any transaction. See repos/contributions.ts.
+	const stored = await buildStoredContribution(row);
+	await putContribution(stored);
+}
+
+/** Mark a staged contribution as landed. Safe to call more than once. */
+export async function confirmContribution(
+	invoiceOfflineId: string,
+): Promise<void> {
+	await markContributionConfirmed(invoiceOfflineId, Date.now());
+}
+
+export interface DerivedExpected {
+	byMop: Record<string, number>;
+	/** Contributions still unconfirmed — surfaced so the UI can say so. */
+	pendingCount: number;
+}
+
+/**
+ * Recompute the shift's contribution total from its rows.
+ *
+ * Pending rows ARE included: the cash was physically taken whether or not the
+ * record reached the server, so excluding it would show the cashier a
+ * shortfall that is not in the drawer. `pendingCount` lets the UI qualify it.
+ */
+export async function deriveExpectedByMop(
+	shiftLifecycleId: string,
+	precision: number,
+): Promise<DerivedExpected> {
+	const rows = await listContributionsForShift(shiftLifecycleId);
+	const byMop: Record<string, number> = {};
+	let pendingCount = 0;
+	const f = 10 ** precision;
+	for (const row of rows) {
+		if (row.status === "pending") pendingCount += 1;
+		for (const [mop, amount] of Object.entries(row.by_mop)) {
+			const next = (byMop[mop] ?? 0) + (Number(amount) || 0);
+			byMop[mop] = Math.round(next * f) / f;
+		}
+	}
+	return { byMop, pendingCount };
+}
+
+/**
+ * Confirm any pending contribution whose invoice the server reports as
+ * submitted. Runs at startup, after a crash between stage and confirm.
+ *
+ * The oracle is `offline.get_shift_invoice_offline_ids`, which returns
+ * `pos_offline_id` for every submitted Sales Invoice on the shift — and both
+ * submit paths persist that id, so it covers live and queued sales alike.
+ */
+export async function reconcilePendingContributions(opts: {
+	openingServerName: string | null;
+	openingOfflineId: string | null;
+}): Promise<{ confirmed: string[]; stillPending: string[] }> {
+	const pending = await listPendingContributions();
+	if (!pending.length) return { confirmed: [], stillPending: [] };
+	if (!opts.openingServerName && !opts.openingOfflineId) {
+		return { confirmed: [], stillPending: pending.map((r) => r.offline_id) };
+	}
+
+	let submitted: string[] = [];
+	try {
+		const { call } = await import("@/utils/call");
+		const result = await call<string[]>({
+			method: "pospire.pospire.api.offline.get_shift_invoice_offline_ids",
+			args: {
+				opening_shift_name: opts.openingServerName,
+				opening_shift_offline_id: opts.openingOfflineId,
+			},
+			intent: "read",
+		});
+		if (Array.isArray(result)) submitted = result.filter(Boolean);
+	} catch (err) {
+		// Offline, or the endpoint is unreachable. Everything stays pending —
+		// that is the safe direction: the amounts still count toward the
+		// displayed total, they are just flagged unconfirmed.
+		console.warn("[contribution-ledger] reconciliation unavailable", err);
+		return { confirmed: [], stillPending: pending.map((r) => r.offline_id) };
+	}
+
+	const landed = new Set(submitted);
+	const confirmed: string[] = [];
+	const stillPending: string[] = [];
+	for (const row of pending) {
+		if (landed.has(row.offline_id)) {
+			await confirmContribution(row.offline_id);
+			confirmed.push(row.offline_id);
+		} else {
+			stillPending.push(row.offline_id);
+		}
+	}
+	return { confirmed, stillPending };
+}
+
+/** Re-export so callers never reach past this module into the repo. */
+export { deleteContributionsForShift };

--- a/frontend/src/offline/contribution-ledger.ts
+++ b/frontend/src/offline/contribution-ledger.ts
@@ -97,6 +97,18 @@ export interface DerivedExpected {
 	byMop: Record<string, number>;
 	/** Contributions still unconfirmed — surfaced so the UI can say so. */
 	pendingCount: number;
+	/**
+	 * Rows whose envelope would not decrypt. Their money is NOT in `byMop`, so
+	 * the caller must fold this into whatever uncertainty it shows: otherwise
+	 * a corrupt row silently shortens a figure that reads as fact.
+	 */
+	skippedCount: number;
+	/**
+	 * The invoice `offline_id` of every row that DID contribute. Lets a caller
+	 * union this total with the outbox scan without double-counting: both
+	 * stores key on the same id.
+	 */
+	offlineIds: string[];
 }
 
 /**
@@ -110,18 +122,21 @@ export async function deriveExpectedByMop(
 	shiftLifecycleId: string,
 	precision: number,
 ): Promise<DerivedExpected> {
-	const rows = await listContributionsForShift(shiftLifecycleId);
+	const { rows, skippedCount } =
+		await listContributionsForShift(shiftLifecycleId);
 	const byMop: Record<string, number> = {};
+	const offlineIds: string[] = [];
 	let pendingCount = 0;
 	const f = 10 ** precision;
 	for (const row of rows) {
+		offlineIds.push(row.offline_id);
 		if (row.status === "pending") pendingCount += 1;
 		for (const [mop, amount] of Object.entries(row.by_mop)) {
 			const next = (byMop[mop] ?? 0) + (Number(amount) || 0);
 			byMop[mop] = Math.round(next * f) / f;
 		}
 	}
-	return { byMop, pendingCount };
+	return { byMop, pendingCount, skippedCount, offlineIds };
 }
 
 /**

--- a/frontend/src/offline/db.ts
+++ b/frontend/src/offline/db.ts
@@ -145,6 +145,22 @@ export class PospireJournalDB extends Dexie {
 export const db = new PospireOfflineDB();
 export const journalDb = new PospireJournalDB();
 
+// LOGGING ONLY. `blocked` fires when this tab's version upgrade cannot proceed
+// because another tab still holds an older connection open. Dexie does not
+// reject the open in that case — it simply waits, so the symptom is "every
+// IndexedDB call in this tab hangs forever" with nothing in the console to
+// explain it. Callers on the sale path defend themselves with their own
+// deadline; this only makes the cause visible.
+//
+// Deliberately NO `versionchange` handler: Dexie's default closes the
+// connection so the OTHER tab's upgrade can complete, and overriding it would
+// turn a transient block into a permanent one.
+db.on("blocked", () => {
+	console.warn(
+		"[offline-db] IndexedDB upgrade is blocked by another open tab; operations in this tab will not settle until it closes",
+	);
+});
+
 // ---------------------------------------------------------------------------
 // Safe mode — state machine flag surfaced to the UI when corruption / storage
 // health is compromised (§8.4).

--- a/frontend/src/offline/db.ts
+++ b/frontend/src/offline/db.ts
@@ -45,6 +45,7 @@ import type {
 	ItemRow,
 	JournalRow,
 	MetadataRow,
+	StoredContributionRow,
 	StoredCustomerRow,
 	StoredOutboxEntry,
 	StoredShiftRow,
@@ -76,6 +77,7 @@ export class PospireOfflineDB extends Dexie {
 	outbox!: Table<StoredOutboxEntry, string>;
 	metadata!: Table<MetadataRow, string>;
 	_health!: Table<HealthProbeRow, string>;
+	contributions!: Table<StoredContributionRow, string>;
 
 	constructor() {
 		super(DB_NAME_PRIMARY);
@@ -105,6 +107,20 @@ export class PospireOfflineDB extends Dexie {
 				"offline_id, status, type, shift_offline_id, [status+next_attempt_at]",
 			metadata: "key",
 			_health: "id",
+		});
+
+		// v2 — per-invoice contribution ledger (Phase 2).
+		//
+		// Purely ADDITIVE: no existing table's schema changes, so Dexie needs
+		// no upgrade function. Devices holding queued invoices and shift rows
+		// keep them; Dexie replays v1 then applies v2's new store.
+		//
+		// Indexed on `shift_lifecycle_id` (every read is shift-scoped) and
+		// `status` (the startup reconciliation scans pending rows). `by_mop`
+		// is deliberately NOT indexed — it is encrypted, and indexing it would
+		// leak amounts into the unencrypted index.
+		this.version(2).stores({
+			contributions: "offline_id, shift_lifecycle_id, status",
 		});
 	}
 }

--- a/frontend/src/offline/repos/contributions.ts
+++ b/frontend/src/offline/repos/contributions.ts
@@ -15,6 +15,7 @@
 
 import { assertWritable, db, runInTransaction } from "../db";
 import { decrypt, encrypt, getActiveKey } from "../crypto";
+import { assertOfflineEnabled } from "../kill-switch";
 import type {
 	ContributionRow,
 	EncryptedEnvelope,
@@ -63,20 +64,22 @@ async function fromStored(
 	};
 }
 
-/** Write a pre-encrypted row. Upsert: re-staging the same invoice overwrites. */
+/**
+ * Write a pre-encrypted row. Upsert: re-staging the same invoice overwrites.
+ *
+ * Gated on the offline kill switch as well as safe mode, matching
+ * `outbox.enqueue`. With offline admin-disabled the device must not be
+ * accumulating encrypted per-invoice money rows on disk: the close dialog will
+ * never source from them (the server owns the figure) and nothing would prune
+ * them. Throws `OfflineDisabledError`; the sale path treats that like any other
+ * staging failure — warn and continue.
+ */
 export async function putContribution(
 	stored: StoredContributionRow,
 ): Promise<void> {
 	assertWritable();
+	await assertOfflineEnabled();
 	await db.contributions.put(stored);
-}
-
-export async function getContribution(
-	offlineId: string,
-): Promise<ContributionRow | undefined> {
-	const stored = await db.contributions.get(offlineId);
-	if (!stored) return undefined;
-	return fromStored(stored);
 }
 
 /**
@@ -87,8 +90,8 @@ export async function getContribution(
  * wasteful — it converts a corrupt envelope into a thrown error on a path that
  * had no business touching the ciphertext. `stageContribution` is exactly that
  * case: it reads only the scalars, and it must be able to overwrite a corrupt
- * row with a fresh one rather than being blocked by it. Use `getContribution`
- * when you genuinely need `by_mop`.
+ * row with a fresh one rather than being blocked by it. The shift-scoped list
+ * helpers below are the only readers that decrypt `by_mop`.
  */
 export async function getStoredContribution(
 	offlineId: string,
@@ -96,32 +99,46 @@ export async function getStoredContribution(
 	return db.contributions.get(offlineId);
 }
 
+export interface ContributionListing {
+	rows: ContributionRow[];
+	/**
+	 * Rows whose envelope would not decrypt. Their money is MISSING from
+	 * `rows`, so callers must surface this rather than presenting the sum as
+	 * fact — a shift with a good 10 and a corrupt 99 derives 10, and a clean
+	 * -looking short number is exactly what a cashier signs off on by mistake.
+	 */
+	skippedCount: number;
+}
+
 /**
  * All contributions for a shift, decrypted row-by-row.
  *
  * A row whose envelope will not decrypt is SKIPPED and logged, not thrown.
  * One corrupt row must cost only its own contribution — an all-or-nothing
- * failure here would silently zero the cashier's expected amount.
+ * failure here would silently zero the cashier's expected amount — but it is
+ * counted so the total can be labelled uncertain.
  */
 export async function listContributionsForShift(
 	shiftLifecycleId: string,
-): Promise<ContributionRow[]> {
+): Promise<ContributionListing> {
 	const stored = await db.contributions
 		.where("shift_lifecycle_id")
 		.equals(shiftLifecycleId)
 		.toArray();
-	const out: ContributionRow[] = [];
+	const rows: ContributionRow[] = [];
+	let skippedCount = 0;
 	for (const row of stored) {
 		try {
-			out.push(await fromStored(row));
+			rows.push(await fromStored(row));
 		} catch (err) {
+			skippedCount += 1;
 			console.warn(
 				`[contributions] skipping undecryptable row ${row.offline_id}`,
 				err,
 			);
 		}
 	}
-	return out;
+	return { rows, skippedCount };
 }
 
 /**

--- a/frontend/src/offline/repos/contributions.ts
+++ b/frontend/src/offline/repos/contributions.ts
@@ -15,7 +15,7 @@
 
 import { assertWritable, db, runInTransaction } from "../db";
 import { decrypt, encrypt, getActiveKey } from "../crypto";
-import { assertOfflineEnabled } from "../kill-switch";
+import { isOfflineEnabledSync, OfflineDisabledError } from "../kill-switch";
 import type {
 	ContributionRow,
 	EncryptedEnvelope,
@@ -73,12 +73,35 @@ async function fromStored(
  * never source from them (the server owns the figure) and nothing would prune
  * them. Throws `OfflineDisabledError`; the sale path treats that like any other
  * staging failure — warn and continue.
+ *
+ * The SYNCHRONOUS read, deliberately, not `assertOfflineEnabled()`. This runs on
+ * the critical path of EVERY sale, and the async path re-fetches from the server
+ * whenever its 60s cache is stale — which during normal ONLINE selling is about
+ * once a minute, because the drain loop that would otherwise keep the cache warm
+ * idles when the outbox is empty. That round trip sits inside the caller's 2s
+ * staging deadline: exceed it on a congested link and the contribution is
+ * skipped, while the sale itself succeeded online and so leaves no outbox row
+ * either — the amount would then be missing from the total, from the gap count
+ * and from the uncertainty count, with the banner still claiming "ledger".
+ * Silent understatement, which is the exact failure class this ledger exists to
+ * remove. The fetch buys nothing here anyway: `fetchKillSwitch` never treats an
+ * error or a missing value as "disabled", so a stale-but-true reading and a
+ * fresh one differ only in latency.
  */
 export async function putContribution(
 	stored: StoredContributionRow,
 ): Promise<void> {
 	assertWritable();
-	await assertOfflineEnabled();
+	if (!isOfflineEnabledSync()) {
+		// `assertOfflineEnabled` logs "blocking enqueue" — wrong noun for a
+		// ledger write, and it would report `outboxType: null`. Say what this
+		// actually is so the console points at the right subsystem.
+		console.warn(
+			"[contributions] offline disabled by administrator; refusing contribution write",
+			{ offline_id: stored.offline_id },
+		);
+		throw new OfflineDisabledError("invoice");
+	}
 	await db.contributions.put(stored);
 }
 

--- a/frontend/src/offline/repos/contributions.ts
+++ b/frontend/src/offline/repos/contributions.ts
@@ -179,6 +179,18 @@ export async function markContributionConfirmed(
 	});
 }
 
+/**
+ * Drop a single staged contribution. For un-staging a sale that never landed
+ * (a 4xx validation error, a deferred return, or any other failure exit after
+ * `stageContribution` ran) — the row must not survive to be summed by
+ * `deriveExpectedByMop`. Bare delete: no crypto, no transaction, since the
+ * row (envelope and all) is simply gone afterward.
+ */
+export async function deleteContribution(offlineId: string): Promise<void> {
+	assertWritable();
+	await db.contributions.delete(offlineId);
+}
+
 /** Drop a shift's contributions once they are no longer needed. */
 export async function deleteContributionsForShift(
 	shiftLifecycleId: string,

--- a/frontend/src/offline/repos/contributions.ts
+++ b/frontend/src/offline/repos/contributions.ts
@@ -80,6 +80,23 @@ export async function getContribution(
 }
 
 /**
+ * The stored row, WITHOUT decrypting `by_mop`.
+ *
+ * For callers that only need the plaintext scalars (`status`, `created_at`,
+ * `confirmed_at`). Decrypting where the plaintext is never read is not merely
+ * wasteful — it converts a corrupt envelope into a thrown error on a path that
+ * had no business touching the ciphertext. `stageContribution` is exactly that
+ * case: it reads only the scalars, and it must be able to overwrite a corrupt
+ * row with a fresh one rather than being blocked by it. Use `getContribution`
+ * when you genuinely need `by_mop`.
+ */
+export async function getStoredContribution(
+	offlineId: string,
+): Promise<StoredContributionRow | undefined> {
+	return db.contributions.get(offlineId);
+}
+
+/**
  * All contributions for a shift, decrypted row-by-row.
  *
  * A row whose envelope will not decrypt is SKIPPED and logged, not thrown.
@@ -107,12 +124,27 @@ export async function listContributionsForShift(
 	return out;
 }
 
-/** Pending rows across every shift — the startup reconciliation's input. */
-export async function listPendingContributions(): Promise<ContributionRow[]> {
-	const stored = await db.contributions
-		.where("status")
-		.equals("pending")
-		.toArray();
+/**
+ * Pending rows for ONE shift — the startup reconciliation's input.
+ *
+ * Scoped to a shift rather than global because the oracle it feeds
+ * (`get_shift_invoice_offline_ids`) is itself scoped to one opening: a pending
+ * row belonging to an earlier shift could never appear in that answer, so a
+ * global query would re-ask about it at every startup forever and report it as
+ * this shift's unconfirmed money.
+ *
+ * Queried on the `shift_lifecycle_id` index and filtered on `status` in memory
+ * — the schema has no compound index, and a shift's row count is small.
+ */
+export async function listPendingContributionsForShift(
+	shiftLifecycleId: string,
+): Promise<ContributionRow[]> {
+	const stored = (
+		await db.contributions
+			.where("shift_lifecycle_id")
+			.equals(shiftLifecycleId)
+			.toArray()
+	).filter((row) => row.status === "pending");
 	const out: ContributionRow[] = [];
 	for (const row of stored) {
 		try {

--- a/frontend/src/offline/repos/contributions.ts
+++ b/frontend/src/offline/repos/contributions.ts
@@ -1,0 +1,159 @@
+/**
+ * Contributions repo — one row per invoice, keyed by the invoice's
+ * `offline_id` (the same id on the live and queued submit paths).
+ *
+ * Only `by_mop` is encrypted: it is per-invoice money. Everything else is a
+ * plaintext scalar so the ledger can query and transition rows without
+ * decrypting anything.
+ *
+ * ENCRYPTION IS NEVER PERFORMED INSIDE A DEXIE TRANSACTION. Awaiting
+ * `crypto.subtle` inside one lets IndexedDB auto-commit early and the call
+ * throws `PrematureCommitError` — this silently disabled a whole feature in
+ * Phase 1. `buildStoredContribution` encrypts outside; the transactional
+ * helpers only ever touch plaintext scalars and pre-built stored rows.
+ */
+
+import { assertWritable, db, runInTransaction } from "../db";
+import { decrypt, encrypt, getActiveKey } from "../crypto";
+import type {
+	ContributionRow,
+	EncryptedEnvelope,
+	StoredContributionRow,
+} from "../types";
+
+function aadForContribution(offlineId: string): string {
+	return `contribution:${offlineId}:by_mop`;
+}
+
+/** Encrypt a contribution into its stored form. Call OUTSIDE any transaction. */
+export async function buildStoredContribution(
+	row: ContributionRow,
+): Promise<StoredContributionRow> {
+	const { key, id } = getActiveKey();
+	const envelope: EncryptedEnvelope = await encrypt(
+		row.by_mop,
+		key,
+		id,
+		aadForContribution(row.offline_id),
+	);
+	return {
+		offline_id: row.offline_id,
+		shift_lifecycle_id: row.shift_lifecycle_id,
+		status: row.status,
+		by_mop_envelope: envelope,
+		created_at: row.created_at,
+		confirmed_at: row.confirmed_at,
+	};
+}
+
+async function fromStored(
+	stored: StoredContributionRow,
+): Promise<ContributionRow> {
+	const by_mop = await decrypt<Record<string, number>>(
+		stored.by_mop_envelope,
+		aadForContribution(stored.offline_id),
+	);
+	return {
+		offline_id: stored.offline_id,
+		shift_lifecycle_id: stored.shift_lifecycle_id,
+		status: stored.status,
+		by_mop,
+		created_at: stored.created_at,
+		confirmed_at: stored.confirmed_at,
+	};
+}
+
+/** Write a pre-encrypted row. Upsert: re-staging the same invoice overwrites. */
+export async function putContribution(
+	stored: StoredContributionRow,
+): Promise<void> {
+	assertWritable();
+	await db.contributions.put(stored);
+}
+
+export async function getContribution(
+	offlineId: string,
+): Promise<ContributionRow | undefined> {
+	const stored = await db.contributions.get(offlineId);
+	if (!stored) return undefined;
+	return fromStored(stored);
+}
+
+/**
+ * All contributions for a shift, decrypted row-by-row.
+ *
+ * A row whose envelope will not decrypt is SKIPPED and logged, not thrown.
+ * One corrupt row must cost only its own contribution — an all-or-nothing
+ * failure here would silently zero the cashier's expected amount.
+ */
+export async function listContributionsForShift(
+	shiftLifecycleId: string,
+): Promise<ContributionRow[]> {
+	const stored = await db.contributions
+		.where("shift_lifecycle_id")
+		.equals(shiftLifecycleId)
+		.toArray();
+	const out: ContributionRow[] = [];
+	for (const row of stored) {
+		try {
+			out.push(await fromStored(row));
+		} catch (err) {
+			console.warn(
+				`[contributions] skipping undecryptable row ${row.offline_id}`,
+				err,
+			);
+		}
+	}
+	return out;
+}
+
+/** Pending rows across every shift — the startup reconciliation's input. */
+export async function listPendingContributions(): Promise<ContributionRow[]> {
+	const stored = await db.contributions
+		.where("status")
+		.equals("pending")
+		.toArray();
+	const out: ContributionRow[] = [];
+	for (const row of stored) {
+		try {
+			out.push(await fromStored(row));
+		} catch (err) {
+			console.warn(
+				`[contributions] skipping undecryptable pending row ${row.offline_id}`,
+				err,
+			);
+		}
+	}
+	return out;
+}
+
+/**
+ * Flip a row to confirmed. Touches plaintext scalars only — the envelope is
+ * carried across untouched, so no crypto runs and the transaction is safe.
+ */
+export async function markContributionConfirmed(
+	offlineId: string,
+	confirmedAt: number,
+): Promise<void> {
+	assertWritable();
+	await runInTransaction("rw", [db.contributions], async () => {
+		const existing = await db.contributions.get(offlineId);
+		if (!existing) return;
+		await db.contributions.put({
+			...existing,
+			status: "confirmed",
+			confirmed_at: confirmedAt,
+		});
+	});
+}
+
+/** Drop a shift's contributions once they are no longer needed. */
+export async function deleteContributionsForShift(
+	shiftLifecycleId: string,
+): Promise<number> {
+	assertWritable();
+	return db.contributions
+		.where("shift_lifecycle_id")
+		.equals(shiftLifecycleId)
+		.delete();
+}

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -345,6 +345,20 @@ export interface QueuedPaymentSum {
 	uncertainCount: number;
 }
 
+export interface QueuedContributionScan extends QueuedPaymentSum {
+	/**
+	 * Per-invoice contributions, keyed by the invoice's `offline_id` — the SAME
+	 * id the contribution ledger keys on (`call()` passes it as
+	 * `offlineIdempotencyKey` and `enqueue` stores it verbatim as the outbox
+	 * row's `offline_id`).
+	 *
+	 * This is what makes a UNION of the two stores exactly computable: the
+	 * close dialog can add the outbox rows the ledger never saw without
+	 * double-counting the ones it did.
+	 */
+	byInvoice: Map<string, Record<string, number>>;
+}
+
 /**
  * Sum queued invoice payments for a shift, by mode of payment.
  *
@@ -480,24 +494,24 @@ export interface QueuedPaymentSum {
  * Invoices whose inner doc fails to parse are NOT counted here — they contribute
  * no money and are a distinct failure mode (unreadable, not merely unconfirmed).
  *
- * This is a STOPGAP for offline-queued sales only (Issue 3, Task 10). Sales
- * made earlier in the shift while online leave no trace in the outbox and are
- * NOT recovered here — that needs the Phase 2 per-invoice contribution
- * ledger. Callers must label whatever they build from this figure provisional.
+ * This scan sees OFFLINE-QUEUED sales only: sales made earlier in the shift
+ * while online leave no trace in the outbox. That is what the Phase 2
+ * contribution ledger exists to cover. Neither store is a superset of the
+ * other, so the close dialog unions them per invoice — see `byInvoice`.
  */
-export async function sumQueuedPaymentsByMop(input: {
+export async function scanQueuedContributionsByInvoice(input: {
 	openingServerName: string | null;
 	shiftOfflineId: string | null;
 	cashMode: string;
 	precision: number;
-}): Promise<QueuedPaymentSum> {
+}): Promise<QueuedContributionScan> {
 	// Without an anchor, `row.shift_offline_id` falsy AND
 	// `readInnerShiftName(row.payload) === null` would match EVERY unanchored
 	// invoice in the outbox — including other shifts' — because `null ===
 	// null`. Refuse to aggregate rather than silently pull in other shifts'
 	// money.
 	if (!input.shiftOfflineId && !input.openingServerName) {
-		return { byMop: {}, uncertainCount: 0 };
+		return { byMop: {}, uncertainCount: 0, byInvoice: new Map() };
 	}
 
 	const buckets: OutboxStatus[] = [
@@ -522,11 +536,12 @@ export async function sumQueuedPaymentsByMop(input: {
 		// vanish silently either — this is the one signal an operator has
 		// that the total is short by an unknown, undecryptable invoice.
 		console.warn(
-			`[shift-lifecycle] sumQueuedPaymentsByMop: skipped ${corruptCount} outbox row(s) that failed to decrypt`,
+			`[shift-lifecycle] scanQueuedContributionsByInvoice: skipped ${corruptCount} outbox row(s) that failed to decrypt`,
 		);
 	}
 
 	const seen = new Set<string>();
+	const byInvoice = new Map<string, Record<string, number>>();
 	const byMop: Record<string, number> = {};
 	let uncertainCount = 0;
 
@@ -572,11 +587,30 @@ export async function sumQueuedPaymentsByMop(input: {
 			input.cashMode,
 			input.precision,
 		);
+		byInvoice.set(row.offline_id, contribution);
 		for (const [mop, amount] of Object.entries(contribution)) {
 			byMop[mop] = round((byMop[mop] ?? 0) + amount, input.precision);
 		}
 	}
 
+	return { byMop, uncertainCount, byInvoice };
+}
+
+/**
+ * The scan's shift total, without the per-invoice breakdown.
+ *
+ * Thin wrapper so the per-invoice arithmetic has exactly one implementation:
+ * callers that only need "what do the queued sales add up to" (the no-lifecycle
+ * -id fallback branch of the close dialog) keep the old shape.
+ */
+export async function sumQueuedPaymentsByMop(input: {
+	openingServerName: string | null;
+	shiftOfflineId: string | null;
+	cashMode: string;
+	precision: number;
+}): Promise<QueuedPaymentSum> {
+	const { byMop, uncertainCount } =
+		await scanQueuedContributionsByInvoice(input);
 	return { byMop, uncertainCount };
 }
 

--- a/frontend/src/offline/shift-lifecycle.ts
+++ b/frontend/src/offline/shift-lifecycle.ts
@@ -567,21 +567,55 @@ export async function sumQueuedPaymentsByMop(input: {
 			uncertainCount += 1;
 		}
 
-		const payments = (inner.payments as Array<Record<string, unknown>>) || [];
-		const change = resolveChangeAmount(inner, payments);
-		for (const p of payments) {
-			const mop = String(p.mode_of_payment ?? "");
-			if (!mop) continue;
-			const raw = Number(p.amount) || 0;
-			const net = mop === input.cashMode ? raw - change : raw;
-			byMop[mop] = round(
-				(byMop[mop] ?? 0) + round(net, input.precision),
-				input.precision,
-			);
+		const contribution = contributionForInvoice(
+			inner,
+			input.cashMode,
+			input.precision,
+		);
+		for (const [mop, amount] of Object.entries(contribution)) {
+			byMop[mop] = round((byMop[mop] ?? 0) + amount, input.precision);
 		}
 	}
 
 	return { byMop, uncertainCount };
+}
+
+/**
+ * Net contribution of ONE invoice, by mode of payment.
+ *
+ * The single source of the per-invoice arithmetic. `sumQueuedPaymentsByMop`
+ * (the Phase 1 outbox-scanning stopgap) and the Phase 2 contribution ledger
+ * both call this, so the two paths cannot drift: cash net of derived change,
+ * every other MOP at face value, each net rounded to the site's precision
+ * before it is accumulated.
+ *
+ * `inner` is the invoice doc itself (already unwrapped from any outbox
+ * payload envelope), so this works identically for a queued sale and for one
+ * being submitted live.
+ *
+ * Every rule here — including the guards, the loyalty term, the
+ * `rounded_total || grand_total` fallback and the clamp at zero — is
+ * documented in full in the doc comments on `sumQueuedPaymentsByMop` and
+ * `resolveChangeAmount`. Read those before changing anything in this
+ * function; it is verified against the server's
+ * `_aggregate_closing_from_invoices`.
+ */
+export function contributionForInvoice(
+	inner: Record<string, unknown>,
+	cashMode: string,
+	precision: number,
+): Record<string, number> {
+	const payments = (inner.payments as Array<Record<string, unknown>>) || [];
+	const change = resolveChangeAmount(inner, payments);
+	const byMop: Record<string, number> = {};
+	for (const p of payments) {
+		const mop = String(p.mode_of_payment ?? "");
+		if (!mop) continue;
+		const raw = Number(p.amount) || 0;
+		const net = mop === cashMode ? raw - change : raw;
+		byMop[mop] = round((byMop[mop] ?? 0) + round(net, precision), precision);
+	}
+	return byMop;
 }
 
 /**

--- a/frontend/src/offline/types.ts
+++ b/frontend/src/offline/types.ts
@@ -215,6 +215,28 @@ export interface StoredShiftRow {
 	closing_notes_envelope: EncryptedEnvelope | null;
 }
 
+export interface ContributionRow {
+	/** Invoice offline_id. Primary key. Same id on the live and queued paths. */
+	offline_id: string;
+	/** Owning shift's lifecycle UUID (db.shifts primary key). */
+	shift_lifecycle_id: string;
+	/** "pending" until the submit is known to have landed. */
+	status: "pending" | "confirmed";
+	/** Encrypted at rest (sensitive financial). MOP name -> net amount. */
+	by_mop: Record<string, number>;
+	created_at: number;
+	confirmed_at: number | null;
+}
+
+export interface StoredContributionRow {
+	offline_id: string;
+	shift_lifecycle_id: string;
+	status: "pending" | "confirmed";
+	by_mop_envelope: EncryptedEnvelope;
+	created_at: number;
+	confirmed_at: number | null;
+}
+
 export interface OutboxEntry<TPayload = unknown> {
 	offline_id: string;
 	type: OutboxType;

--- a/frontend/src/pages/ObservabilityPage.vue
+++ b/frontend/src/pages/ObservabilityPage.vue
@@ -143,7 +143,7 @@
               </tr>
               <tr v-if="!outlets.length">
                 <td colspan="6" class="observability-page__empty">
-                  {{ __('No beacons yet — devices report every 5 minutes.') }}
+                  {{ __('No beacons yet. Devices report every 5 minutes.') }}
                 </td>
               </tr>
             </tbody>
@@ -174,7 +174,7 @@
               </v-list-item>
             </v-list>
             <p class="observability-page__hint" v-if="buildHashes.length > 1">
-              {{ __('Multiple builds in flight — likely a staged rollout. Three or more usually means a device fleet stuck on stale code.') }}
+              {{ __('Multiple builds in flight. Likely a staged rollout. Three or more usually means a device fleet stuck on stale code.') }}
             </p>
           </v-card-text>
         </v-card>


### PR DESCRIPTION
## Summary

Phase 2 of the offline shift lifecycle work. Fixes the third field-reported bug.

**Issue 3 — the offline close-shift dialog showed only the opening float.** With Cash 5000 / CC 2000 rung up, going offline and opening the close dialog showed just the float. Offline bills contributed under *Submit* but not under *Submit & Print*.

> **Stacked on #50**. Review that one first. This PR's diff is the 16 commits on top; GitHub will retarget the base to `version_16_dev` automatically once Phase 1 merges.

## Approach

A per-invoice contribution ledger keyed by the invoice `offline_id`:

- **Staged** before submit, **confirmed** after, **discarded** on failure, and **reconciled** at startup for anything left pending by a crash or a closed tab.
- The close-dialog total is **derived** from ledger rows, never accumulated into a running counter. An accumulator drifts on every retry, double-submit or partial failure; a derived total cannot.
- Both the live-submit and outbox-enqueue paths are hooked, which is what fixes the Submit vs Submit & Print asymmetry.
- Rows are pruned once the shift's closing has synced, on both the normal and the reconciliation path.

New Dexie store at `version(2)`, indexed on `shift_lifecycle_id` and `status`. `by_mop` is deliberately **not** indexed: it is encrypted, and indexing it would leak amounts into the unencrypted index. Encryption happens in `buildStoredContribution`, outside any transaction, per the `PrematureCommitError` constraint.

The staging path is wrapped in a 2s `Promise.race` so the ledger can never block a sale. A ledger failure degrades the close figure; it does not stop the cashier.

## Notable review catches

- The close figure originally branched on whether the shift id was *resolvable* rather than whether the ledger had *content*. On upgrade day that would have shown 200 where Phase 1 showed 1700. The landed version takes the **union** of the ledger and an outbox scan by invoice `offline_id`, so a device that rang invoices on a pre-ledger build still reports correctly.
- A scan failure could blank an already-healthy ledger figure. Now it cannot.
- The kill switch is read synchronously on the staging path; an async read let one sale through before the switch took effect.
- `Payments.vue` has no `pos_opening_shift` state of its own, and `App.vue`'s `register_pos_profile` emitter hands out an unstamped live response that overwrites the good cached one. The shift lifecycle id is resolved at sale time instead.

## Files

16 commits, 17 files, +1076/−72. New: `offline/contribution-ledger.ts`, `offline/repos/contributions.ts`. Modified: `offline/db.ts` (v2 schema), `offline/types.ts`, `Payments.vue`, `Pos.vue`.

Also folds in a copy pass removing em-dashes from user-facing offline toasts and the offline banner (20 strings, 10 files). No translations were orphaned; `pt.csv` had no matching msgids.

## Testing

Manually tested, including the upgrade-day path (invoices rung on a Phase 1 build, then loaded on this build mid-shift) and a v2 schema upgrade on a device holding queued data. Full suite: 121 passing. No new tests.

## Risk: the Dexie upgrade is a one-way door

Once a browser opens the app on this build, IndexedDB records database version 2. Shipping code that declares only `version(1)` afterwards fails the open with a `VersionError`, meaning the offline DB does not open at all — a worse failure than whatever prompted the rollback.

A clean revert of this PR is therefore only safe **while no device has run this build**. After any real deployment, rollback means a forward fix, or a revert that keeps the `version(2).stores(...)` declaration and removes only the ledger logic.

This is the main reason the two phases are separate PRs: reverting Phase 2 should not cost you the Phase 1 fixes.

## Merging

Please use **Create a merge commit**, not squash. Merge Phase 1 first.
