### PR TITLE
fix(offline): insert closing payloads as draft so on_submit runs

### DIFF
--- a/pospire/pospire/api/offline.py
+++ b/pospire/pospire/api/offline.py
@@ -96,21 +96,46 @@ _UUID_V4_RE = re.compile(
 )
 
 # Framework-managed fields that the offline payload carries from the cart but
-# the server must own at replay time. Letting these leak through corrupts
-# server-side identity / optimistic-concurrency state:
-#   - name         → autoname series assigns; cart-stamped name causes
-#                    DoesNotExistError on subsequent get_doc lookups
+# the server must own at replay time. Used on both write paths: to filter cart
+# fields on the invoice-update flows, and to strip a fresh insert payload in
+# `_idempotent_submit` (which re-applies `doctype` afterwards). Letting these
+# leak through corrupts server-side identity / optimistic-concurrency state:
+#   - name         → autoname assigns the real name. Frappe's `set_new_name`
+#                    already nulls a cart-stamped one for every autoname we
+#                    use (naming_series / series), so a leaked name is inert —
+#                    stripping it keeps the payload from implying otherwise
 #   - modified     → cart-stamped value defeats Frappe's check_if_latest
 #                    (TimestampMismatchError on every save)
 #   - creation     → audit trail; the cart only knew the online-load time,
 #                    not the actual server insert time
 #   - modified_by  → set_user_and_timestamp owns this from session.user
 #   - owner        → _acting_as_user already attributes correctly
-#   - docstatus    → posapp.submit_invoice transitions this; cart's value
-#                    (typically 0) shouldn't override mid-flow
+#   - docstatus    → the cart stamps `1` on opening/closing payloads. Inserting
+#                    an already-submitted row turns the follow-up `.submit()`
+#                    into an update-after-submit, which (a) never runs
+#                    `on_submit`, so POSClosingShift never closes the opening
+#                    shift, and (b) compares in-memory floats against the
+#                    rounded DB values — the UpdateAfterSubmitError on
+#                    Grand Total that broke offline close on the prospect site
 _OFFLINE_PAYLOAD_RESERVED = frozenset(
 	{"doctype", "name", "modified", "creation", "modified_by", "owner", "docstatus"}
 )
+
+
+def _currency_precision() -> int:
+	"""Site currency precision used when aggregating closing totals."""
+	return cint(frappe.get_cached_value("System Settings", None, "currency_precision")) or 3
+
+
+def _float_precision() -> int:
+	"""Site float precision used when aggregating closing quantities.
+
+	The `or 3` fallback mirrors Frappe's own default for non-Currency fields
+	(`get_field_precision` in frappe/model/meta.py). Falling back to anything
+	tighter would round `total_quantity` below the precision of the Float
+	field it lands on — visible on sites selling by weight.
+	"""
+	return cint(frappe.get_cached_value("System Settings", None, "float_precision")) or 3
 
 
 def _throw(error_code: str, message: str, details: dict[str, Any] | None = None) -> None:
@@ -235,6 +260,11 @@ def _idempotent_submit(
 	When `owner_user` is supplied, the insert + submit run inside
 	`_acting_as_user(owner_user)` so the doc is attributed to the original
 	cashier rather than the replay session (P-5).
+
+	Cart-stamped fields in `_OFFLINE_PAYLOAD_RESERVED` (see the note on that
+	constant for why each one) are stripped before `frappe.get_doc`, so a
+	closing payload with `docstatus: 1` is inserted as a draft and then
+	submitted properly. `doctype` is re-applied after the strip.
 	"""
 	existing = _existing_by_offline_id(doctype, offline_id)
 	if existing:
@@ -276,7 +306,9 @@ def _idempotent_submit(
 		}
 
 	payload = dict(payload)
-	payload.setdefault("doctype", doctype)
+	for key in _OFFLINE_PAYLOAD_RESERVED:
+		payload.pop(key, None)
+	payload["doctype"] = doctype
 	payload["pos_offline_id"] = offline_id
 	if device_id is not None:
 		payload["pos_device_id"] = device_id
@@ -1764,14 +1796,16 @@ def _aggregate_closing_from_invoices(
 		)
 		pay_expected[py.mode_of_payment] = pay_expected.get(py.mode_of_payment, 0.0) + flt(py.paid_amount)
 
+	precision = _currency_precision()
+	qty_precision = _float_precision()
 	return {
 		"pos_transactions": pos_transactions,
-		"taxes": taxes,
+		"taxes": [{**tx, "amount": flt(tx["amount"], precision)} for tx in taxes],
 		"pos_payments": pos_payments,
-		"grand_total": grand_total,
-		"net_total": net_total,
-		"total_quantity": total_quantity,
-		"pay_expected": pay_expected,
+		"grand_total": flt(grand_total, precision),
+		"net_total": flt(net_total, precision),
+		"total_quantity": flt(total_quantity, qty_precision),
+		"pay_expected": {mop: flt(amt, precision) for mop, amt in pay_expected.items()},
 	}
 
 

--- a/pospire/pospire/tests/test_offline.py
+++ b/pospire/pospire/tests/test_offline.py
@@ -29,7 +29,7 @@ from unittest.mock import patch
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_days, getdate, nowdate
+from frappe.utils import add_days, cint, getdate, now_datetime, nowdate
 
 from pospire.pospire.api.offline import (
 	ERROR_ACCOUNTING_PERIOD_CLOSED,
@@ -49,11 +49,13 @@ from pospire.pospire.api.offline import (
 	_idempotent_submit,
 	_resolve_opening_shift,
 	_resolve_opening_shift_flexible,
+	create_closing_entry,
 	get_offline_flags_for_shift,
 	is_offline_enabled,
 	snapshot_profile_flags_onto_opening_shift,
 )
 from pospire.pospire.tests.test_utils import (
+	create_test_opening_shift,
 	ensure_test_company,
 	ensure_test_customer,
 	get_test_pos_profile,
@@ -249,6 +251,68 @@ class TestEnrichClosingPayload(FrappeTestCase):
 		self.assertEqual(len(agg["pos_transactions"]), 1)
 		self.assertEqual(agg["pos_transactions"][0]["sales_invoice"], "INV-OFFLINE-001")
 
+	def test_grand_total_rounded_to_currency_precision(self):
+		"""IEEE-754 sum of invoice totals must not leak past currency precision.
+
+		20000.05 + 44660.05 is 64660.100000000006 in IEEE-754 (the same
+		class of noise as the prospect OSR-2026-00005 Grand Total error).
+		Quantity uses the same sum-then-round pattern with float precision.
+		"""
+		noisy_a = 20000.05
+		noisy_b = 44660.05
+		self.assertNotEqual(noisy_a + noisy_b, 64660.1)
+		self.assertNotEqual(0.1 + 0.2, 0.3)
+
+		def fake_get_all(doctype, filters=None, pluck=None, fields=None, **kwargs):
+			filters = filters or {}
+			if doctype == "POS Opening Shift Detail":
+				return []
+			if doctype == "Sales Invoice" and pluck == "name":
+				return ["INV-A", "INV-B"] if filters.get("posa_pos_opening_shift") else []
+			if doctype == "Sales Invoice":
+				return [
+					frappe._dict(
+						name="INV-A",
+						posting_date="2026-08-18",
+						grand_total=noisy_a,
+						net_total=noisy_a,
+						total_qty=0.1,
+						customer="Cust A",
+						change_amount=0,
+					),
+					frappe._dict(
+						name="INV-B",
+						posting_date="2026-08-18",
+						grand_total=noisy_b,
+						net_total=noisy_b,
+						total_qty=0.2,
+						customer="Cust B",
+						change_amount=0,
+					),
+				]
+			if doctype in ("Sales Invoice Payment", "Sales Taxes and Charges", "Payment Entry"):
+				return []
+			return []
+
+		def fake_get_cached_value(doctype, name=None, field=None, **kwargs):
+			if doctype == "System Settings":
+				return 2
+			return None
+
+		with (
+			patch("pospire.pospire.api.offline.frappe.get_all", side_effect=fake_get_all),
+			patch(
+				"pospire.pospire.api.offline.frappe.get_cached_value",
+				side_effect=fake_get_cached_value,
+			),
+			patch("pospire.pospire.api.offline.frappe.db.get_value", return_value=None),
+		):
+			agg = _aggregate_closing_from_invoices("POSA-OS-TEST", None)
+
+		self.assertEqual(agg["grand_total"], 64660.1)
+		self.assertEqual(agg["net_total"], 64660.1)
+		self.assertEqual(agg["total_quantity"], 0.3)
+
 
 # ---------------------------------------------------------------------------
 # Idempotency tests — `_idempotent_submit` docstatus-aware branches (C2/RM2)
@@ -262,6 +326,121 @@ class TestIdempotentSubmit(FrappeTestCase):
 		"""The cheap existence probe returns None when the offline_id has
 		never been seen for the given doctype."""
 		self.assertIsNone(_existing_by_offline_id("Sales Invoice", _make_offline_id()))
+
+	def test_insert_payload_strips_cart_docstatus(self):
+		"""Cart closing payloads stamp `docstatus: 1`. If that leaks into
+		`frappe.get_doc` + insert, Frappe writes a submitted row and the
+		follow-up `.submit()` becomes update-after-submit — which is how
+		the prospect Grand Total float noise turned into UpdateAfterSubmitError.
+		"""
+		captured: dict = {}
+
+		def fake_get_doc(payload):
+			captured["payload"] = dict(payload)
+			raise AssertionError("stop-after-get-doc")
+
+		with (
+			patch("pospire.pospire.api.offline._existing_by_offline_id", return_value=None),
+			patch("pospire.pospire.api.offline.frappe.get_doc", side_effect=fake_get_doc),
+		):
+			with self.assertRaises(AssertionError):
+				_idempotent_submit(
+					"POS Closing Shift",
+					{
+						"docstatus": 1,
+						"name": "POSA-CS-SHOULD-NOT-LEAK",
+						"owner": "ravneet.bedi@promantia.com",
+						"grand_total": 64660.10000000002,
+					},
+					_UUID_VALID,
+					device_id=_UUID_VALID_2,
+				)
+
+		payload = captured["payload"]
+		self.assertNotIn("docstatus", payload)
+		self.assertNotIn("name", payload)
+		self.assertNotIn("owner", payload)
+		self.assertEqual(payload["doctype"], "POS Closing Shift")
+		self.assertEqual(payload["pos_offline_id"], _UUID_VALID)
+		self.assertEqual(payload["pos_device_id"], _UUID_VALID_2)
+
+	def test_closing_submit_closes_opening_without_repair(self):
+		"""Cart `docstatus: 1` must still insert a draft and run on_submit.
+
+		That is the real repair: POSClosingShift.on_submit marks the opening
+		Closed. `_ensure_opening_closed` is a safety net and must be a no-op
+		on this path (`opening_shift_repaired` stays unset).
+		"""
+		# Profile-first, NOT the `ensure_test_company()` + `get_test_pos_profile()`
+		# idiom used elsewhere in this file. Both helpers are "first row" lookups,
+		# not fixtures, so that idiom silently skips on any site whose first
+		# Company happens to own no POS Profile. Taking the profile and reading
+		# its company back off it keeps the pair consistent and the test running.
+		profile_row = frappe.get_all("POS Profile", fields=["name", "company"], limit=1)
+		if profile_row:
+			company, pos_profile = profile_row[0].company, profile_row[0].name
+		else:
+			company = ensure_test_company()
+			pos_profile = get_test_pos_profile(company)
+		if not pos_profile:
+			self.skipTest("No POS Profile available for testing")
+
+		# NB: if that profile has `posa_allow_delete`, POSClosingShift.on_submit
+		# also runs delete_draft_invoices(). Harmless here — the opening shift is
+		# created fresh, so no Sales Invoice links to it.
+		opening = create_test_opening_shift(company, pos_profile)
+		closing_name = None
+		try:
+			result = create_closing_entry(
+				data={
+					"doctype": "POS Closing Shift",
+					"period_start_date": opening.period_start_date,
+					"period_end_date": now_datetime(),
+					"posting_date": nowdate(),
+					"user": "Administrator",
+					"pos_profile": pos_profile,
+					"company": company,
+					"docstatus": 1,
+					"name": "POSA-CS-SHOULD-NOT-LEAK",
+					"payment_reconciliation": [
+						{
+							"mode_of_payment": "Cash",
+							"opening_amount": 0,
+							"closing_amount": 0,
+							"expected_amount": 0,
+						}
+					],
+					"grand_total": 64660.10000000002,
+					"owner_user": "Administrator",
+					"invoice_offline_ids": [],
+					"pos_opening_shift": opening.name,
+				},
+				offline_id=_make_offline_id(),
+				device_id=_make_offline_id(),
+				opening_entry_ref=opening.name,
+			)
+			closing_name = result.get("name")
+			self.assertTrue(closing_name)
+			self.assertNotEqual(closing_name, "POSA-CS-SHOULD-NOT-LEAK")
+			self.assertEqual(cint(result.get("docstatus")), 1)
+			self.assertFalse(result.get("was_already_submitted"))
+			self.assertNotIn("opening_shift_repaired", result)
+
+			opening.reload()
+			self.assertEqual(opening.status, "Closed")
+			self.assertEqual(opening.pos_closing_shift, closing_name)
+		finally:
+			with suppress(Exception):
+				if closing_name:
+					closing = frappe.get_doc("POS Closing Shift", closing_name)
+					if cint(closing.docstatus) == 1:
+						closing.cancel()
+					frappe.delete_doc("POS Closing Shift", closing_name, force=True, ignore_permissions=True)
+			with suppress(Exception):
+				opening.reload()
+				if cint(opening.docstatus) == 1:
+					opening.cancel()
+				frappe.delete_doc("POS Opening Shift", opening.name, force=True, ignore_permissions=True)
 
 	def test_replay_against_cancelled_doc_throws_validation_error(self):
 		"""docstatus=2 → cannot replay; throws ERROR_VALIDATION so client


### PR DESCRIPTION
## Problem

Offline shift close failed on the prospect site (pospire-v16.fsn.frappe.cloud) as
OSR-2026-00005, stuck in Pending Review with:

> Not allowed to change Grand Total after submission from 64660.1 to 64660.10000000002

Two compounding causes:

**1. The closing payload was inserted already-submitted.** The client stamps
`docstatus: 1` on the closing payload, and `_idempotent_submit` passed it straight
into `frappe.get_doc(...).insert()`. Frappe's `insert()` does not force `docstatus`
back to 0, so the row was written submitted, and the follow-up `.submit()` became an
update-after-submit. Two consequences:

- `on_submit` **never ran**, so `POSClosingShift` never closed the opening shift —
  which is why the `_ensure_opening_closed` band-aid existed at all.
- `_validate_update_after_submit` compares in-memory values against DB values with
  exact float equality.

**2. Closing totals were summed as raw floats.** `_aggregate_closing_from_invoices`
produced `64660.10000000002` in memory against `64660.1` in the decimal column.
Combined with (1), that raised `UpdateAfterSubmitError` on Grand Total.

## Fix

- Strip `_OFFLINE_PAYLOAD_RESERVED` (`docstatus`, `name`, `owner`, `modified`,
  `creation`, `modified_by`) from fresh insert payloads in `_idempotent_submit`,
  re-applying `doctype` after. Close now runs draft → submit, so `on_submit` fires
  for real.
- Round aggregated closing currency fields (`grand_total`, `net_total`,
  `taxes[].amount`, `pay_expected`) to site currency precision, and `total_quantity`
  to site float precision, so the in-memory sum matches what the column stores.

## Behaviour change — please read

Because `on_submit` now genuinely runs, `POSClosingShift.delete_draft_invoices()`
goes live on the offline path. On a POS Profile with `posa_allow_delete`, closing a
shift will force-delete draft unprinted Sales Invoices under that opening shift.

This is parity with the existing **online** close path, not a new class of behaviour
— but it has never fired offline before, so it is worth a conscious sign-off.

## Verification — partial, please read

**The test file added here has never been executed.** `bench run-tests` aborts during
fixture setup with `Year start date or end date is overlapping with Fiscal Year
2025-2026`, before any test runs. `--skip-test-records` is a no-op in v16. Do not
read the added tests as passing.

What *was* verified, by driving the code paths directly against a dev site inside a
transaction and rolling back:

- End-to-end close: payload with `docstatus: 1` and a leaked `name` → result
  `docstatus` 1, autoname won (name not leaked), opening status `Closed`, and
  `opening_shift_repaired` **absent** — that last point is the real proof `on_submit`
  ran rather than the band-aid.
- Aggregation rounding: raw sum `64660.100000000006` → `grand_total` `64660.1`.
- Insert payload after strip: `['doctype', 'grand_total', 'pos_device_id',
  'pos_offline_id']` — `docstatus`, `name`, `owner` all gone.
- Precision helpers: site-set → currency=2 float=2; unset → currency=3 float=3.
- `ruff check` and `ruff format --check` clean on both files.

Nothing was persisted to the dev site.

## Release routing

`pospire/pospire/api/offline.py` exists only on `version_16_dev` — the offline
feature is not on `version-16` — so this cannot ride the normal patch-release line.
Getting it to the prospect site is a deliberate deployment decision, not automatic.
