### PR TITLE
fix(pos): deliver remote approval requests to managers

### DIFF
--- a/frontend/__tests__/utils/approvalStep.test.ts
+++ b/frontend/__tests__/utils/approvalStep.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { isApprovalFlagOn, resolveInitialApprovalStep } from "@/utils/approvalStep";
+
+describe("isApprovalFlagOn", () => {
+	it("treats Frappe Check on-values as enabled", () => {
+		expect(isApprovalFlagOn(1)).toBe(true);
+		expect(isApprovalFlagOn("1")).toBe(true);
+		expect(isApprovalFlagOn(true)).toBe(true);
+	});
+
+	it("treats Frappe Check off-values as disabled, including string zero", () => {
+		expect(isApprovalFlagOn(0)).toBe(false);
+		expect(isApprovalFlagOn("0")).toBe(false);
+		expect(isApprovalFlagOn(false)).toBe(false);
+		expect(isApprovalFlagOn(null)).toBe(false);
+		expect(isApprovalFlagOn(undefined)).toBe(false);
+		expect(isApprovalFlagOn("")).toBe(false);
+	});
+});
+
+describe("resolveInitialApprovalStep", () => {
+	it("returns choose when PIN and remote are both available", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 1, remote_approval: 1 }, true),
+		).toBe("choose");
+	});
+
+	it("returns pin when only PIN is enabled", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 1, remote_approval: 0 }, true),
+		).toBe("pin");
+	});
+
+	it("returns pin when remote is on the action but the profile flag is off", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 1, remote_approval: 1 }, false),
+		).toBe("pin");
+	});
+
+	it("returns waiting when only remote is available", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 0, remote_approval: 1 }, true),
+		).toBe("waiting");
+	});
+
+	it("returns misconfigured when neither PIN nor remote is available", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 0, remote_approval: 0 }, true),
+		).toBe("misconfigured");
+		expect(
+			resolveInitialApprovalStep({ pin_approval: 0, remote_approval: 1 }, false),
+		).toBe("misconfigured");
+		expect(resolveInitialApprovalStep({}, true)).toBe("misconfigured");
+	});
+
+	it("does not treat a string zero PIN flag as enabled", () => {
+		expect(
+			resolveInitialApprovalStep({ pin_approval: "0", remote_approval: 1 }, true),
+		).toBe("waiting");
+	});
+});

--- a/frontend/src/components/pos/ApprovalDialog.vue
+++ b/frontend/src/components/pos/ApprovalDialog.vue
@@ -210,6 +210,26 @@
 				</v-card-actions>
 			</template>
 
+			<!-- Misconfigured: no usable approval channel, or nobody to notify -->
+			<template v-else-if="step === 'misconfigured'">
+				<v-card-title class="pospire-modal-header">
+					<div class="pospire-modal-icon icon-danger">
+						<v-icon size="24">mdi-alert-circle-outline</v-icon>
+					</div>
+					<div>
+						<div class="pospire-modal-title">{{ __("Approval Not Configured") }}</div>
+						<div class="text-body-2">{{ actionLabel }}</div>
+					</div>
+				</v-card-title>
+				<v-card-text class="pospire-modal-body">
+					<p class="text-body-2">{{ config_error }}</p>
+				</v-card-text>
+				<v-card-actions class="pospire-modal-actions">
+					<v-spacer></v-spacer>
+					<v-btn class="pospire-modal-btn-secondary" @click="close(false)">{{ __("Close") }}</v-btn>
+				</v-card-actions>
+			</template>
+
 			<!-- Result -->
 			<template v-else-if="step === 'result'">
 				<v-card-title class="pospire-modal-header">
@@ -233,6 +253,7 @@
 
 <script>
 import { call } from "@/utils/call";
+import { resolveInitialApprovalStep } from "@/utils/approvalStep";
 import { toast } from "vue3-toastify";
 
 export default {
@@ -269,6 +290,7 @@ export default {
 			loading: false,
 			result: null,
 			resolved_by_name: null,
+			config_error: "",
 		};
 	},
 
@@ -306,11 +328,20 @@ export default {
 			this.selected_remote_manager = null;
 			this.pin_input = "";
 			this.resolution_note = "";
+			this.config_error = "";
 			this._stop_status_poll();
 
+			const planned = resolveInitialApprovalStep(this.actionConfig, this.remoteApprovalEnabled);
+			if (planned === "misconfigured") {
+				this.config_error = __(
+					"Approval is required but neither PIN nor remote approval is available. Ask a system manager to enable Allow PIN Approval or Allow Remote Approval on this POS Profile action.",
+				);
+				this.step = "misconfigured";
+				return;
+			}
+
 			try {
-				const { pin_approval, remote_approval } = this.actionConfig || {};
-				const both_modes = !!(pin_approval && remote_approval && this.remoteApprovalEnabled);
+				const both_modes = planned === "choose";
 
 				const r = await call("pospire.pospire.api.approval.create_approval_request", {
 					pos_profile: this.posProfile,
@@ -327,23 +358,12 @@ export default {
 				});
 				this.request_name = r.name;
 				window.frappe?.realtime?.on("pos_approval_resolved", this._on_resolved);
-				this._set_initial_step();
+				this.step = planned;
 				this._start_status_poll();
-			} catch {
-				toast.error(__("Failed to create approval request"));
-				this.close(false);
-			}
-		},
-
-		_set_initial_step() {
-			const { pin_approval, remote_approval } = this.actionConfig || {};
-			const remote_available = !!(remote_approval && this.remoteApprovalEnabled);
-			if (pin_approval && remote_available) {
-				this.step = "choose";
-			} else if (pin_approval) {
-				this.step = "pin";
-			} else {
-				this.step = "waiting";
+			} catch (e) {
+				this.config_error = this._server_error(e) || __("Failed to create approval request");
+				toast.error(this.config_error);
+				this.step = "misconfigured";
 			}
 		},
 
@@ -360,10 +380,22 @@ export default {
 					request_name: this.request_name,
 					selected_manager: this.selected_remote_manager || null,
 				});
-			} catch {
-				// non-fatal — fall through to waiting
+				this.step = "waiting";
+			} catch (e) {
+				this.config_error =
+					this._server_error(e) ||
+					__(
+						"Could not notify a manager. Check that this action has an Approver Role with at least one user.",
+					);
+				toast.error(this.config_error);
+				if (this.request_name) {
+					call("pospire.pospire.api.approval.cancel_approval_request", {
+						request_name: this.request_name,
+					}).catch(() => {});
+					this.request_name = null;
+				}
+				this.step = "misconfigured";
 			}
-			this.step = "waiting";
 		},
 
 		_start_status_poll() {
@@ -416,6 +448,14 @@ export default {
 				this.loading = false;
 				this.pin_input = "";
 			}
+		},
+
+		_server_error(e) {
+			const msgs = e?.messages;
+			if (Array.isArray(msgs) && msgs.length && typeof msgs[0] === "string" && msgs[0].trim()) {
+				return msgs[0];
+			}
+			return null;
 		},
 
 		_parse_pin_error(e) {

--- a/frontend/src/utils/approvalStep.ts
+++ b/frontend/src/utils/approvalStep.ts
@@ -1,0 +1,25 @@
+/**
+ * Decide which ApprovalDialog screen to show for a required action.
+ *
+ * Frappe Check values may arrive as 1/0, true/false, or "1"/"0". Only the
+ * explicit on-values count as enabled — a string "0" must not be treated as
+ * truthy.
+ */
+
+export type ApprovalDialogStep = "choose" | "pin" | "waiting" | "misconfigured";
+
+export function isApprovalFlagOn(value: unknown): boolean {
+	return value === true || value === 1 || value === "1";
+}
+
+export function resolveInitialApprovalStep(
+	actionConfig: { pin_approval?: unknown; remote_approval?: unknown } | null | undefined,
+	remoteApprovalEnabled: boolean,
+): ApprovalDialogStep {
+	const pin = isApprovalFlagOn(actionConfig?.pin_approval);
+	const remote = isApprovalFlagOn(actionConfig?.remote_approval) && !!remoteApprovalEnabled;
+	if (pin && remote) return "choose";
+	if (pin) return "pin";
+	if (remote) return "waiting";
+	return "misconfigured";
+}

--- a/pospire/pospire/api/approval.py
+++ b/pospire/pospire/api/approval.py
@@ -6,7 +6,7 @@ import string
 
 import frappe
 from frappe import _
-from frappe.utils import add_to_date, now_datetime
+from frappe.utils import add_to_date, cint, now_datetime
 from werkzeug.security import check_password_hash, generate_password_hash
 
 _PIN_ATTEMPT_CACHE_PREFIX = "posa_pin_attempts"
@@ -189,6 +189,22 @@ def create_approval_request(
 	action_config = _get_action_config(pos_profile, action_type)
 	expiry_minutes = (action_config or {}).get("expiry_minutes") or 15
 
+	pin_ok = _flag_on((action_config or {}).get("pin_approval"))
+	remote_ok = _remote_available(pos_profile, action_config)
+	if not pin_ok and not remote_ok:
+		frappe.throw(
+			_(
+				"Approval is required but neither PIN nor remote approval is available. "
+				"Enable Allow PIN Approval or Allow Remote Approval on this action, "
+				"and Enable Remote Approval on the POS Profile."
+			)
+		)
+
+	if broadcast and remote_ok:
+		# Fail before insert so a broken remote config cannot leave a Pending request
+		# that nobody will ever see.
+		_require_remote_recipients(action_config or {}, selected_manager)
+
 	doc = frappe.get_doc(
 		{
 			"doctype": "POS Approval Request",
@@ -214,42 +230,54 @@ def create_approval_request(
 	)
 	doc.insert(ignore_permissions=True)
 
-	if broadcast and action_config and action_config.get("remote_approval"):
+	if broadcast and remote_ok:
 		_broadcast_request_to_managers(doc, action_config, selected_manager)
 
 	return doc.as_dict()
 
 
-def _broadcast_request_to_managers(
-	doc: frappe.model.document.Document,
-	action_config: dict,
-	selected_manager: str | None = None,
-) -> None:
-	"""Broadcast the approval request via WebSocket to the relevant manager(s).
+def _flag_on(value) -> bool:
+	return bool(cint(value))
 
-	If the cashier selected a specific manager, notify only that one.
-	Otherwise notify all managers with the configured approver role + active PIN.
-	"""
-	approver_role = action_config.get("approver_role")
-	if not approver_role:
-		return
 
+def _remote_available(pos_profile: str, action_config: dict | None) -> bool:
+	if not action_config or not _flag_on(action_config.get("remote_approval")):
+		return False
+	return bool(frappe.db.get_value("POS Profile", pos_profile, "posa_enable_remote_approval"))
+
+
+def _get_remote_recipients(action_config: dict, selected_manager: str | None = None) -> list[str]:
 	if selected_manager:
-		recipients = [selected_manager]
-	else:
-		# For remote approval notifications, include all users with the approver role
-		# (PIN is only required for PIN-based approval, not remote desk approval).
-		recipients = frappe.get_all(
-			"Has Role",
-			filters={"role": approver_role, "parenttype": "User"},
-			pluck="parent",
+		return [selected_manager]
+	approver_role = (action_config or {}).get("approver_role")
+	if not approver_role:
+		return []
+	return frappe.get_all(
+		"Has Role",
+		filters={"role": approver_role, "parenttype": "User"},
+		pluck="parent",
+	)
+
+
+def _require_remote_recipients(action_config: dict, selected_manager: str | None = None) -> list[str]:
+	approver_role = (action_config or {}).get("approver_role")
+	if not selected_manager and not approver_role:
+		frappe.throw(
+			_(
+				"Cannot send a remote approval request because this action has no Approver Role. "
+				"Ask a system manager to set one on the POS Profile."
+			)
 		)
-
+	recipients = _get_remote_recipients(action_config, selected_manager)
 	if not recipients:
-		return
+		frappe.throw(
+			_("Cannot send a remote approval request because no user has the role {0}.").format(approver_role)
+		)
+	return recipients
 
+
+def _publish_approval_to_users(doc: frappe.model.document.Document, recipients: list[str]) -> None:
 	cashier_name = frappe.db.get_value("User", doc.requested_by, "full_name") or doc.requested_by
-
 	message = {
 		"request_name": doc.name,
 		"action_type": doc.action_type,
@@ -263,13 +291,27 @@ def _broadcast_request_to_managers(
 		"pos_profile": doc.pos_profile,
 		"expires_at": str(doc.expires_at),
 	}
-
 	for manager_user in recipients:
 		frappe.publish_realtime(
 			event="pos_approval_request",
 			message=message,
 			user=manager_user,
 		)
+
+
+def _broadcast_request_to_managers(
+	doc: frappe.model.document.Document,
+	action_config: dict,
+	selected_manager: str | None = None,
+) -> None:
+	"""Broadcast the approval request via WebSocket to the relevant manager(s).
+
+	If the cashier selected a specific manager, notify only that one.
+	Otherwise notify all users with the configured approver role.
+	Raises if nobody can be notified — a silent no-op left cashiers waiting.
+	"""
+	recipients = _require_remote_recipients(action_config, selected_manager)
+	_publish_approval_to_users(doc, recipients)
 
 
 # ---------------------------------------------------------------------------
@@ -421,34 +463,15 @@ def notify_remote_manager(request_name: str, selected_manager: str | None = None
 		frappe.throw(_("Approval request {0} is no longer pending.").format(request_name))
 
 	action_config = _get_action_config(doc.pos_profile, doc.action_type) or {}
-	cashier_name = frappe.db.get_value("User", doc.requested_by, "full_name") or doc.requested_by
-
-	message = {
-		"request_name": doc.name,
-		"action_type": doc.action_type,
-		"item_code": doc.item_code,
-		"item_name": doc.item_name,
-		"original_value": doc.original_value,
-		"requested_value": doc.requested_value,
-		"value_field_label": doc.value_field_label,
-		"requested_by": doc.requested_by,
-		"requested_by_full_name": cashier_name,
-		"pos_profile": doc.pos_profile,
-		"expires_at": str(doc.expires_at),
-	}
-
-	if selected_manager:
-		frappe.publish_realtime(event="pos_approval_request", message=message, user=selected_manager)
-	else:
-		approver_role = action_config.get("approver_role")
-		recipients = (
-			frappe.get_all("Has Role", filters={"role": approver_role, "parenttype": "User"}, pluck="parent")
-			if approver_role
-			else []
+	if not _remote_available(doc.pos_profile, action_config):
+		frappe.throw(
+			_(
+				"Remote approval is not enabled for this action. Enable Allow Remote Approval "
+				"on the action and Enable Remote Approval on the POS Profile."
+			)
 		)
-		for user in recipients:
-			frappe.publish_realtime(event="pos_approval_request", message=message, user=user)
 
+	_broadcast_request_to_managers(doc, action_config, selected_manager)
 	return {"status": "notified"}
 
 

--- a/pospire/pospire/doctype/pos_approval_action/pos_approval_action.py
+++ b/pospire/pospire/doctype/pos_approval_action/pos_approval_action.py
@@ -2,10 +2,30 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
 
 
 class POSApprovalAction(Document):
+	def validate(self) -> None:
+		if self.approval_mode != "Required":
+			return
+		pin = cint(self.pin_approval)
+		remote = cint(self.remote_approval)
+		if not pin and not remote:
+			frappe.throw(
+				_(
+					"Action {0} is Required but neither Allow PIN Approval nor Allow Remote Approval is enabled."
+				).format(self.action_type or _("this action"))
+			)
+		if remote and not self.approver_role:
+			frappe.throw(
+				_("Approver Role is required when Remote Approval is enabled for {0}.").format(
+					self.action_type or _("this action")
+				)
+			)
+
 	def before_save(self) -> None:
 		if self.condition:
 			self.condition_js = _normalize_condition_to_js(self.condition)

--- a/pospire/pospire/doctype/pos_profile/pos_profile.py
+++ b/pospire/pospire/doctype/pos_profile/pos_profile.py
@@ -21,3 +21,17 @@ def validate_pos_profile(doc, method):
 					assortment_company, doc.company
 				)
 			)
+
+	_validate_approval_actions(doc)
+
+
+def _validate_approval_actions(doc):
+	"""Run the POS Approval Action rules from the parent.
+
+	Frappe never invokes a child DocType's validate() on parent save --
+	Document.run_before_save_methods() calls run_method("validate") on the parent
+	only, and run_method() does not cascade to children. Driving the child rules
+	from here is what makes them actually enforced on save.
+	"""
+	for row in doc.get("posa_approval_actions") or []:
+		row.validate()

--- a/pospire/pospire/tests/test_approval.py
+++ b/pospire/pospire/tests/test_approval.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, POSpire and contributors
+# For license information, please see license.txt
+
+"""Approval request broadcast and configuration guards.
+
+Covers the silent-wait defects: broadcasting with no recipients, and creating
+a request when neither PIN nor remote approval is actually available.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import frappe
+from frappe.tests import UnitTestCase
+from frappe.utils import now_datetime
+
+from pospire.pospire.api.approval import (
+	_broadcast_request_to_managers,
+	create_approval_request,
+)
+from pospire.pospire.doctype.pos_approval_action.pos_approval_action import POSApprovalAction
+from pospire.pospire.doctype.pos_profile.pos_profile import validate_pos_profile
+
+
+def _request_stub():
+	return frappe._dict(
+		name="POSA-AR-TEST",
+		action_type="Edit Rate",
+		item_code=None,
+		item_name=None,
+		original_value=None,
+		requested_value=None,
+		value_field_label=None,
+		requested_by="Administrator",
+		pos_profile="_Test Profile",
+		expires_at=now_datetime(),
+	)
+
+
+class TestBroadcastRequestToManagers(UnitTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_throws_when_approver_role_is_blank(self):
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			_broadcast_request_to_managers(_request_stub(), {"approver_role": ""}, None)
+		self.assertIn("Approver Role", str(ctx.exception))
+
+	def test_throws_when_no_user_holds_approver_role(self):
+		with patch("pospire.pospire.api.approval.frappe.get_all", return_value=[]):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				_broadcast_request_to_managers(_request_stub(), {"approver_role": "POS Manager"}, None)
+			self.assertIn("no user has the role", str(ctx.exception).lower())
+
+	def test_publishes_one_realtime_event_per_recipient(self):
+		recipients = ["manager-a@example.com", "manager-b@example.com"]
+		real_get_all = frappe.get_all
+
+		def fake_get_all(doctype, *args, **kwargs):
+			if doctype == "Has Role":
+				return recipients
+			return real_get_all(doctype, *args, **kwargs)
+
+		with (
+			patch("pospire.pospire.api.approval.frappe.get_all", side_effect=fake_get_all),
+			patch("pospire.pospire.api.approval.frappe.publish_realtime") as publish,
+		):
+			_broadcast_request_to_managers(_request_stub(), {"approver_role": "POS Manager"}, None)
+			self.assertEqual(publish.call_count, 2)
+			users = [c.kwargs["user"] for c in publish.call_args_list]
+			self.assertEqual(users, recipients)
+			for c in publish.call_args_list:
+				self.assertEqual(c.kwargs["event"], "pos_approval_request")
+
+
+class TestCreateApprovalRequestConfig(UnitTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_throws_when_neither_pin_nor_remote_is_available(self):
+		profile = frappe.db.get_value("POS Profile", {}, "name")
+		if not profile:
+			self.skipTest("No POS Profile on this site")
+		with patch(
+			"pospire.pospire.api.approval._get_action_config",
+			return_value={
+				"pin_approval": 0,
+				"remote_approval": 0,
+				"expiry_minutes": 15,
+				"approver_role": "POS Manager",
+			},
+		):
+			with self.assertRaises(frappe.ValidationError) as ctx:
+				create_approval_request(
+					pos_profile=profile,
+					action_type="Edit Rate",
+					broadcast=True,
+				)
+			self.assertIn("neither PIN nor remote", str(ctx.exception))
+
+
+def _action_row(**overrides):
+	values = {
+		"doctype": "POS Approval Action",
+		"action_type": "Edit Rate",
+		"approval_mode": "Required",
+		"pin_approval": 0,
+		"remote_approval": 0,
+	}
+	values.update(overrides)
+	return POSApprovalAction(values)
+
+
+def _profile_stub(rows):
+	"""Minimal stand-in for the POS Profile doc the validate hook receives."""
+	return frappe._dict(
+		custom_assortment=None,
+		item_groups=[],
+		company="_Test Company",
+		posa_approval_actions=rows,
+	)
+
+
+class TestPOSApprovalActionValidate(UnitTestCase):
+	"""Drive the rules through validate_pos_profile, the hook registered for
+	POS Profile in hooks.py. Calling POSApprovalAction.validate() directly would
+	pass even if nothing ran it on save -- Frappe does not invoke a child
+	DocType's validate() on parent save.
+	"""
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def test_required_mode_rejects_both_channels_off(self):
+		doc = _profile_stub([_action_row(pin_approval=0, remote_approval=0)])
+		with self.assertRaises(frappe.ValidationError):
+			validate_pos_profile(doc, "validate")
+
+	def test_remote_requires_approver_role(self):
+		doc = _profile_stub([_action_row(remote_approval=1, approver_role="")])
+		with self.assertRaises(frappe.ValidationError) as ctx:
+			validate_pos_profile(doc, "validate")
+		self.assertIn("Approver Role", str(ctx.exception))
+
+	def test_valid_rows_pass(self):
+		doc = _profile_stub(
+			[
+				_action_row(pin_approval=1),
+				_action_row(remote_approval=1, approver_role="POS Manager"),
+				_action_row(approval_mode="Not Required"),
+			]
+		)
+		validate_pos_profile(doc, "validate")

--- a/pospire/public/js/pos_approval_desk.js
+++ b/pospire/public/js/pos_approval_desk.js
@@ -4,9 +4,22 @@
 // Desk-side approval notification handler.
 // Shows actionable Approve/Reject dialog to managers when a cashier requests remote approval.
 
-frappe.realtime.on("pos_approval_request", function (data) {
-	_show_approval_dialog(data);
-});
+// frappe.realtime.on() silently no-ops while frappe.realtime.socket is undefined
+// (see RealTimeClient.on() in frappe/public/js/frappe/socketio_client.js). The
+// socket is only created by frappe.realtime.init(), which runs inside
+// Application.startup() on document.ready — long after this app_include_js file
+// executes during <body> parse. Binding here directly would never register.
+function _bind_approval_listener() {
+	frappe.realtime.on("pos_approval_request", function (data) {
+		_show_approval_dialog(data);
+	});
+}
+
+if (frappe.realtime && frappe.realtime.socket) {
+	_bind_approval_listener();
+} else {
+	$(document).on("app_ready", _bind_approval_listener);
+}
 
 function _show_approval_dialog(data) {
 	var cashier = data.requested_by_full_name || data.requested_by || __("A cashier");


### PR DESCRIPTION
## Problem

A cashier requesting remote approval sat on **Waiting for Manager** forever — no manager ever received the Approve/Reject popup, on any desk page, for any user.

Root cause: `pos_approval_desk.js` called `frappe.realtime.on(...)` at the top level of an `app_include_js` script. Those run as blocking `<script>` tags during `<body>` parse, but `frappe.realtime.socket` is only created by `frappe.realtime.init()`, which runs from `$(document).ready` → `Application.startup()`. Frappe's `RealTimeClient.on()` is guarded by `if (this.socket)`, so the call silently no-opped — no error, no console warning. The listener never registered. The server was publishing correctly the whole time.

## Changes

**The delivery bug** — bind the listener on the `app_ready` event, which fires after `realtime.init()`. Same pattern as `erpnext/public/js/utils.js`.

**No more waiting on an approval nobody will answer:**

- The dialog's step resolution moved to `frontend/src/utils/approvalStep.ts` and now returns an explicit `misconfigured` state. Previously the final `else` sent the cashier to "waiting" without checking that remote was actually available. It also treats Frappe Check values correctly — the old inline check read the string `"0"` as enabled.
- Broadcasting with no recipients (no Approver Role, or nobody holding it) now throws instead of silently returning. The check runs *before* insert, so a broken config can't leave an orphan Pending row, and the dialog surfaces the server message instead of spinning.
- The POS Profile now rejects a `Required` action with both channels off, or remote enabled with no Approver Role.

The config rules live on `POSApprovalAction` but are driven from `validate_pos_profile()`, because **Frappe never invokes a child DocType's `validate()` on parent save** — `run_before_save_methods()` calls `run_method("validate")` on the parent only, and it doesn't cascade. A child-side `validate()` would have been dead code.

## Testing

- `bench run-tests --module pospire.pospire.tests.test_approval` — 7/7
- `vitest __tests__/utils/approvalStep.test.ts` — 8/8
- The POS Profile guard test is mutation-verified: removing the wiring from `validate_pos_profile` makes exactly those cases fail. Asserting on `POSApprovalAction.validate()` directly would pass even though nothing runs it.
- Verified manually on a local site: manager receives and resolves requests from any desk page.

## Follow-ups (pre-existing, not addressed here)

- `POSApprovalAction.before_save()` has the same dead-child-hook problem, so `condition_js` is likely never auto-populated — configured conditions may silently never apply.
- `_get_remote_recipients()` doesn't verify that an explicitly selected manager holds the approver role. They can't approve (`resolve_approval_request` checks), so impact is limited to a stray notification.
- `get_pending_approvals` is whitelisted but unused — there's no manager queue UI, so a missed popup is only recoverable from the raw list view.