### PR TITLE
33388-33386: Tax inclusive hiding from UI and revamp the customer search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- POS Profile's "Tax Inclusive" setting now controls whether an invoice's tax is calculated inclusive or exclusive of item price, replacing the old always-inclusive default. Existing POS Profiles are backfilled to inclusive (matching prior behaviour) during the upgrade.
+
+### Known limitation
+- Unchecking "Tax Inclusive" on a POS Profile can block offline payments on sites whose tax template uses a charge type other than "On Net Total" — offline tax computation only supports that charge type, so the cashier will be asked to reconnect before completing the sale in that case.
+
 ## [1.0.0] - 2026-02-17
 
 First stable release of POSpire — a modern, full-featured Point of Sale application built on ERPNext.

--- a/frontend/src/components/pos/Customer.vue
+++ b/frontend/src/components/pos/Customer.vue
@@ -1,66 +1,67 @@
 <template>
 	<div>
-		<v-autocomplete
-			density="compact"
-			clearable
-			auto-select-first
-			variant="outlined"
-			color="primary"
-			:label="__('Customer')"
-			v-model="customer"
-			:items="customers"
-			item-title="customer_name"
-			item-value="name"
-			:no-data-text="__('Customers not found')"
-			hide-details
-			:customFilter="customFilter"
-			:disabled="readonly"
-		>
-			<template #prepend-inner>
+		<div class="d-flex align-center customer-search-row">
+			<div v-if="showActions" class="customer-actions d-flex align-center mr-2">
 				<v-icon
-					v-if="showActions"
 					class="customer-action-icon mr-2"
 					color="primary"
 					@click.stop="edit_customer"
 				>mdi-account-edit</v-icon>
 				<v-icon
-					v-if="showActions"
-					class="customer-action-icon mr-1"
+					class="customer-action-icon"
 					color="primary"
 					@click.stop="new_customer"
 				>mdi-account-plus</v-icon>
-			</template>
-			<template v-slot:item="{ props, item }">
-				<v-list-item v-bind="props">
-					<template v-slot:append v-if="isPendingSync(item.raw)">
-						<v-chip
-							size="x-small"
-							color="warning"
-							variant="tonal"
-							:title="__('This customer was created offline and has not yet synced to the server.')"
-						>
-							<v-icon start size="x-small">mdi-cloud-sync-outline</v-icon>
-							{{ __('pending sync') }}
-						</v-chip>
-					</template>
-					<v-list-item-subtitle v-if="item.raw.customer_name != item.raw.name">
-						<div>ID: {{ item.raw.name }}</div>
-					</v-list-item-subtitle>
-					<v-list-item-subtitle v-if="item.raw.tax_id">
-						<div>TAX ID: {{ item.raw.tax_id }}</div>
-					</v-list-item-subtitle>
-					<v-list-item-subtitle v-if="item.raw.email_id">
-						<div>Email: {{ item.raw.email_id }}</div>
-					</v-list-item-subtitle>
-					<v-list-item-subtitle v-if="item.raw.mobile_no">
-						<div>Mobile No: {{ item.raw.mobile_no }}</div>
-					</v-list-item-subtitle>
-					<v-list-item-subtitle v-if="item.raw.primary_address">
-						<div>Primary Address: {{ item.raw.primary_address }}</div>
-					</v-list-item-subtitle>
-				</v-list-item>
-			</template>
-		</v-autocomplete>
+			</div>
+			<v-autocomplete
+				class="flex-grow-1"
+				density="compact"
+				clearable
+				auto-select-first
+				variant="outlined"
+				color="primary"
+				:label="__('Customer')"
+				v-model="customer"
+				:items="customers"
+				item-title="customer_name"
+				item-value="name"
+				:no-data-text="__('Customers not found')"
+				hide-details
+				:customFilter="customFilter"
+				:disabled="readonly"
+			>
+				<template v-slot:item="{ props, item }">
+					<v-list-item v-bind="props">
+						<template v-slot:append v-if="isPendingSync(item.raw)">
+							<v-chip
+								size="x-small"
+								color="warning"
+								variant="tonal"
+								:title="__('This customer was created offline and has not yet synced to the server.')"
+							>
+								<v-icon start size="x-small">mdi-cloud-sync-outline</v-icon>
+								{{ __('pending sync') }}
+							</v-chip>
+						</template>
+						<v-list-item-subtitle v-if="item.raw.customer_name != item.raw.name">
+							<div>ID: {{ item.raw.name }}</div>
+						</v-list-item-subtitle>
+						<v-list-item-subtitle v-if="item.raw.tax_id">
+							<div>TAX ID: {{ item.raw.tax_id }}</div>
+						</v-list-item-subtitle>
+						<v-list-item-subtitle v-if="item.raw.email_id">
+							<div>Email: {{ item.raw.email_id }}</div>
+						</v-list-item-subtitle>
+						<v-list-item-subtitle v-if="item.raw.mobile_no">
+							<div>Mobile No: {{ item.raw.mobile_no }}</div>
+						</v-list-item-subtitle>
+						<v-list-item-subtitle v-if="item.raw.primary_address">
+							<div>Primary Address: {{ item.raw.primary_address }}</div>
+						</v-list-item-subtitle>
+					</v-list-item>
+				</template>
+			</v-autocomplete>
+		</div>
 
 		<UpdateCustomer />
 	</div>

--- a/frontend/src/components/pos/Customer.vue
+++ b/frontend/src/components/pos/Customer.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
-		<div class="d-flex align-center customer-search-row">
-			<div v-if="showActions" class="customer-actions d-flex align-center mr-2">
+		<div class="d-flex align-center">
+			<div v-if="showActions" class="d-flex align-center mr-2">
 				<v-icon
 					class="customer-action-icon mr-2"
 					color="primary"

--- a/frontend/src/components/pos/Customer.vue
+++ b/frontend/src/components/pos/Customer.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<div class="d-flex align-center">
-			<div v-if="showActions" class="d-flex align-center mr-2">
+			<div v-if="showActions && !readonly" class="d-flex align-center mr-2">
 				<v-icon
 					class="customer-action-icon mr-2"
 					color="primary"

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -64,14 +64,14 @@
 			<!-- Fixed Customer Selector Section (Fixed at Top) -->
 			<div class="invoice-header-section">
 				<v-row align="center" no-gutters class="px-3 py-2">
-					<!-- Customer: 8 cols with sales order, 9 cols without -->
+					<!-- Customer: 10 cols with sales order, 12 cols without -->
 					<v-col
 						:cols="
 							$vuetify.display.mdAndDown
 								? 12
 								: pos_profile.posa_allow_sales_order
-									? 8
-									: 9
+									? 10
+									: 12
 						"
 						class="pr-2"
 					>
@@ -94,33 +94,6 @@
 							v-model="invoiceType"
 							:disabled="invoiceType == 'Return'"
 						/>
-					</v-col>
-					<!-- Inclusive Tax: 2 cols with sales order, 3 cols without -->
-					<v-col
-						:cols="
-							$vuetify.display.mdAndDown
-								? 12
-								: pos_profile.posa_allow_sales_order
-									? 2
-									: 3
-						"
-						class="pl-2 d-flex align-center justify-end"
-					>
-						<v-switch
-							v-model="inclusive_tax"
-							:color="inclusive_tax ? 'primary' : 'grey'"
-							:base-color="inclusive_tax ? 'primary' : 'grey'"
-							inset
-							density="compact"
-							hide-details
-							class="small-switch flex-shrink-0"
-						>
-							<template v-slot:label>
-								<span class="text-nowrap text-body-2">{{
-									__("Inclusive Tax")
-								}}</span>
-							</template>
-						</v-switch>
 					</v-col>
 					<!-- Return Mode Badge -->
 					<v-col
@@ -4313,6 +4286,7 @@ export default {
 				this.float_precision = window.sys_defaults?.float_precision || 2;
 				this.currency_precision = window.sys_defaults?.currency_precision || 2;
 				this.invoiceType = this.pos_profile.posa_default_sales_order ? "Order" : "Invoice";
+				this.inclusive_tax = Boolean(this.pos_profile.posa_tax_inclusive);
 				this.load_approval_config();
 				// Prime the tax config while online so it's cached for offline use.
 				this.load_offline_tax_config();
@@ -4528,11 +4502,6 @@ export default {
 
 .disable-events {
 	pointer-events: none;
-}
-.small-switch .v-label {
-	margin-left: -6px;
-	margin-top: 20px; /* Adjust this value as needed */
-	display: block;
 }
 
 /* .pay-button {

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -64,14 +64,16 @@
 			<!-- Fixed Customer Selector Section (Fixed at Top) -->
 			<div class="invoice-header-section">
 				<v-row align="center" no-gutters class="px-3 py-2">
-					<!-- Customer: 10 cols with sales order, 12 cols without -->
+					<!-- Customer: 10 cols with sales order, 12 (or 10 in return mode) without -->
 					<v-col
 						:cols="
 							$vuetify.display.mdAndDown
 								? 12
 								: pos_profile.posa_allow_sales_order
 									? 10
-									: 12
+									: invoice_doc.is_return
+										? 10
+										: 12
 						"
 						class="pr-2"
 					>
@@ -1137,7 +1139,8 @@ export default {
 	data() {
 		return {
 			//
-			inclusive_tax: true,
+			// Transient until register_pos_profile lands and sets the real value.
+			inclusive_tax: false,
 			// Cached tax config + last offline tax estimate (see @/offline/tax).
 			offline_tax_config: null,
 			offline_tax_supported: true,

--- a/frontend/src/components/pos/Invoice.vue
+++ b/frontend/src/components/pos/Invoice.vue
@@ -64,13 +64,15 @@
 			<!-- Fixed Customer Selector Section (Fixed at Top) -->
 			<div class="invoice-header-section">
 				<v-row align="center" no-gutters class="px-3 py-2">
-					<!-- Customer: 10 cols with sales order, 12 (or 10 in return mode) without -->
+					<!-- Customer: 8/10 cols with sales order (return/non-return), 10/12 without -->
 					<v-col
 						:cols="
 							$vuetify.display.mdAndDown
 								? 12
 								: pos_profile.posa_allow_sales_order
-									? 10
+									? invoice_doc.is_return
+										? 8
+										: 10
 									: invoice_doc.is_return
 										? 10
 										: 12

--- a/pospire/fixtures/custom_field.json
+++ b/pospire/fixtures/custom_field.json
@@ -4576,7 +4576,7 @@
   "fetch_if_empty": 0,
   "fieldname": "posa_tax_inclusive",
   "fieldtype": "Check",
-  "hidden": 1,
+  "hidden": 0,
   "hide_border": 0,
   "hide_days": 0,
   "hide_seconds": 0,

--- a/pospire/fixtures/property_setter.json
+++ b/pospire/fixtures/property_setter.json
@@ -17,22 +17,6 @@
  },
  {
   "default_value": null,
-  "doc_type": "POS Profile",
-  "docstatus": 0,
-  "doctype": "Property Setter",
-  "doctype_or_field": "DocField",
-  "field_name": "posa_tax_inclusive",
-  "is_system_generated": 0,
-  "modified": "2025-02-24 11:32:35.406244",
-  "module": "POSpire",
-  "name": "POS Profile-posa_tax_inclusive-hidden",
-  "property": "hidden",
-  "property_type": "Check",
-  "row_name": null,
-  "value": "0"
- },
- {
-  "default_value": null,
   "doc_type": "Sales Invoice",
   "docstatus": 0,
   "doctype": "Property Setter",

--- a/pospire/fixtures/property_setter.json
+++ b/pospire/fixtures/property_setter.json
@@ -29,7 +29,7 @@
   "property": "hidden",
   "property_type": "Check",
   "row_name": null,
-  "value": "1"
+  "value": "0"
  },
  {
   "default_value": null,

--- a/pospire/hooks.py
+++ b/pospire/hooks.py
@@ -391,7 +391,6 @@ fixtures = [
 				"in",
 				(
 					"Sales Invoice-posa_pos_opening_shift-no_copy",
-					"POS Profile-posa_tax_inclusive-hidden",
 					"Sales Invoice-main-field_order",
 					"POS Profile-main-field_order",
 				),

--- a/pospire/patches.txt
+++ b/pospire/patches.txt
@@ -7,3 +7,4 @@
 pospire.patches.v1_1.remove_denomination_breakdown_at_closing_field
 pospire.patches.v1_1.add_strict_closure_compound_index
 pospire.patches.v1_1.repair_unclosed_opening_shifts
+pospire.patches.v1_1.remove_tax_inclusive_hidden_property_setter

--- a/pospire/patches/v1_1/remove_tax_inclusive_hidden_property_setter.py
+++ b/pospire/patches/v1_1/remove_tax_inclusive_hidden_property_setter.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026, Promantia Business Solutions PVT Ltd and Contributors
+# See license.txt
+
+"""Drop the Property Setter that used to hide POS Profile.posa_tax_inclusive.
+
+The field is now visible via the Custom Field itself. Fixture sync never
+deletes records dropped from a fixture file, so sites installed before this
+change keep the old setter and the field stays hidden.
+
+Also backfills posa_tax_inclusive to 1 on POS Profiles created before this
+field existed. The field's own "default": "1" only applies to newly inserted
+rows, so a pre-existing profile sits at 0 - Check fields get a NOT NULL
+DEFAULT 0 column, they are never actually NULL. The frontend used to hardcode
+tax-inclusive behaviour regardless of this field, so a profile at 0 silently
+switching to tax-exclusive would change real invoice totals with no warning.
+
+Safe to backfill unconditionally at 0: before this change the field was
+hidden and had no effect, so no site could have deliberately unchecked it.
+"""
+
+import frappe
+
+
+def execute():
+	frappe.delete_doc(
+		"Property Setter",
+		"POS Profile-posa_tax_inclusive-hidden",
+		ignore_missing=True,
+		force=True,
+	)
+	frappe.clear_cache(doctype="POS Profile")
+
+	frappe.db.sql("update `tabPOS Profile` set posa_tax_inclusive = 1 where posa_tax_inclusive = 0")

--- a/pospire/patches/v1_1/remove_tax_inclusive_hidden_property_setter.py
+++ b/pospire/patches/v1_1/remove_tax_inclusive_hidden_property_setter.py
@@ -7,15 +7,17 @@ The field is now visible via the Custom Field itself. Fixture sync never
 deletes records dropped from a fixture file, so sites installed before this
 change keep the old setter and the field stays hidden.
 
-Also backfills posa_tax_inclusive to 1 on POS Profiles created before this
-field existed. The field's own "default": "1" only applies to newly inserted
-rows, so a pre-existing profile sits at 0 - Check fields get a NOT NULL
-DEFAULT 0 column, they are never actually NULL. The frontend used to hardcode
-tax-inclusive behaviour regardless of this field, so a profile at 0 silently
-switching to tax-exclusive would change real invoice totals with no warning.
+Also backfills posa_tax_inclusive to 1 as a safety net.
 
-Safe to backfill unconditionally at 0: before this change the field was
-hidden and had no effect, so no site could have deliberately unchecked it.
+In normal cases this matches no rows. Frappe puts the field's own
+default into the ADD COLUMN statement, so the column is created as
+NOT NULL DEFAULT 1 and the database fills existing rows with 1 at
+that moment. Profiles older than the field are already correct.
+
+It only matters in one edge case: a site where the column was created
+while the field had no default and the default was added afterwards,
+because ALTER COLUMN SET DEFAULT does not touch rows that already
+exist. Cheap to keep, so we keep it.
 """
 
 import frappe
@@ -30,4 +32,5 @@ def execute():
 	)
 	frappe.clear_cache(doctype="POS Profile")
 
-	frappe.db.sql("update `tabPOS Profile` set posa_tax_inclusive = 1 where posa_tax_inclusive = 0")
+	if frappe.db.has_column("POS Profile", "posa_tax_inclusive"):
+		frappe.db.sql("update `tabPOS Profile` set posa_tax_inclusive = 1 where posa_tax_inclusive = 0")


### PR DESCRIPTION
33388-33386: Tax inclusive hiding from UI and revamp the customer search bar

changes:

Unhid posa_tax_inclusive on POS Profile (hidden: 0 in custom_field.json)
Removed redundant POS Profile-posa_tax_inclusive-hidden Property Setter + its hooks.py fixture reference
Wired invoice inclusive_tax to pos_profile.posa_tax_inclusive in register_pos_profile handler (Invoice.vue)
Removed manual "Inclusive Tax" toggle from invoice header UI
Rebalanced Customer/Type/Return-badge column widths after toggle removal; fixed 12-col overflow in return mode
Changed inclusive_tax default in data() from true to false (transient pre-profile-load value)
Moved "Edit Customer" / "New Customer" icons out of the search box's prepend-inner slot into a separate sibling element (Customer.vue)
Removed dead CSS classes (.customer-search-row, .customer-actions)